### PR TITLE
Cleanup some warnings

### DIFF
--- a/src/MediaPage.vala
+++ b/src/MediaPage.vala
@@ -441,8 +441,6 @@ public abstract class MediaPage : CheckerboardPage {
         set_action_sensitive ("RemoveFromLibrary", selected_count > 0);
         set_action_sensitive ("MoveToTrash", selected_count > 0);
 
-        set_action_sensitive ("Rate", selected_count > 0);
-
         update_development_menu_item_sensitivity ();
 
         update_flag_action (selected_count);

--- a/src/db/DatabaseTable.vala
+++ b/src/db/DatabaseTable.vala
@@ -67,7 +67,7 @@ public abstract class DatabaseTable {
     public static void init (string filename) {
         // Open DB.
         prepare_db (filename);
-        GLib.warning ("NAME: %s", filename);
+        info ("Loading database: %s", filename);
 
         // Try a query to make sure DB is intact; if not, try to use the backup
         Sqlite.Statement stmt;

--- a/src/sidebar/metadata/BasicProperties.vala
+++ b/src/sidebar/metadata/BasicProperties.vala
@@ -60,9 +60,9 @@ private class BasicProperties : Properties {
         flash = "";
         filesize = 0;
         focal_length = "";
-        gps_lat = -1;
+        gps_lat = 0.0;
         gps_lat_ref = "";
-        gps_long = -1;
+        gps_long = 0.0;
         gps_long_ref = "";
         photo_count = -1;
         event_count = -1;
@@ -285,7 +285,7 @@ private class BasicProperties : Properties {
             }
         }
 
-        if (gps_lat != -1 && gps_long != -1) {
+        if (gps_lat != 0.0 && gps_long != 0.0) {
             place_label = new Properties.Label ("");
             place_label.no_show_all = true;
             place_label.visible = false;
@@ -401,7 +401,7 @@ private class BasicProperties : Properties {
                 place_label.visible = true;
             }
         } catch (Error e) {
-            warning ("Failed to obtain place: %s", e.message);
+            warning ("Failed to obtain place for %f, %f: %s", lat, long, e.message);
         }
     }
 


### PR DESCRIPTION
Been doing some debugging on photos recently and there's a few noisy warnings in the output.

* One was relating to an action called "Rate" which doesn't seem to exist anymore, so I've removed the remnant of that code that was causing the warning.

* The second was a `warning` every time the database was loaded. Changed that to an info log message instead.

* The last was a lot of failures with the reverse geocoding. The default for an unset lat and long was `-1` but it seemed the library used for fetching the lat and long from the photo was returning `0.0, 0.0` when the photo didn't have those tags set. `0.0, 0.0` is in the middle of the ocean below africa, so I don't think we'll have any photos taken there, and we're now avoiding running the geocoding code on all the photos without a location set.