### PR TITLE
Don't remove timeouts that don't exist anymore

### DIFF
--- a/src/Page.vala
+++ b/src/Page.vala
@@ -1069,15 +1069,19 @@ public abstract class Page : Gtk.ScrolledWindow {
     }
 
     public void stop_cursor_hiding () {
-        if (last_timeout_id != 0)
+        if (last_timeout_id != 0) {
             Source.remove (last_timeout_id);
+            last_timeout_id = 0;
+        }
     }
 
     public void suspend_cursor_hiding () {
         cursor_hide_time_cached = cursor_hide_msec;
 
-        if (last_timeout_id != 0)
+        if (last_timeout_id != 0) {
             Source.remove (last_timeout_id);
+            last_timeout_id = 0;
+        }
 
         cursor_hide_msec = 0;
     }
@@ -1114,6 +1118,7 @@ public abstract class Page : Gtk.ScrolledWindow {
         if (event_source != null)
             event_source.get_window ().set_cursor (new Gdk.Cursor.for_display (Gdk.Display.get_default (), Gdk.CursorType.BLANK_CURSOR));
 
+        last_timeout_id = 0;
         return false;
     }
 }


### PR DESCRIPTION
There were a bunch of fatals while in slideshow mode about trying to remove timeouts that couldn't be found.

Make sure we don't do that anymore.