### PR TITLE
Support WebP image files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="cmake desktop-file-utils intltool libaccounts-glib-dev libexif-dev libgee-0.8-dev libgeocode-glib-dev libgexiv2-dev libglib2.0-dev libgphoto2-dev libgranite-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libgudev-1.0-dev libjson-glib-dev libraw-dev librest-dev libsignon-glib-dev libsoup2.4-dev libsqlite3-dev libunity-dev libwebkit2gtk-4.0-dev libxml2 python-scour valac"
+ - DEPENDENCY_PACKAGES="cmake desktop-file-utils intltool libaccounts-glib-dev libexif-dev libgee-0.8-dev libgeocode-glib-dev libgexiv2-dev libglib2.0-dev libgphoto2-dev libwebp-dev libgranite-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libgudev-1.0-dev libjson-glib-dev libraw-dev librest-dev libsignon-glib-dev libsoup2.4-dev libsqlite3-dev libunity-dev libwebkit2gtk-4.0-dev libxml2 python-scour valac"
 
 install:
  - docker pull elementary/docker:loki

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set (DEPS_PKG
     json-glib-1.0
     libexif>=0.6.16
     libgphoto2>=2.4.2
+    libwebp>=0.4.4
     libraw>=0.13.2
     libsoup-2.4>=2.26.0
     libxml-2.0>=2.6.32
@@ -60,6 +61,7 @@ set (DEPS_PACKAGES
     gudev-1.0
     libexif
     libgphoto2
+    libwebp
     json-glib-1.0
     libraw
     libsoup-2.4

--- a/data/org.pantheon.photos-viewer.desktop.in.in
+++ b/data/org.pantheon.photos-viewer.desktop.in.in
@@ -8,7 +8,7 @@ Terminal=false
 NoDisplay=true
 Type=Application
 StartupNotify=true
-MimeType=image/jpeg;image/jpg;image/pjpeg;image/png;image/tiff;image/gif;image/x-3fr;image/x-adobe-dng;image/x-arw;image/x-bay;image/x-bmp;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-pef;image/x-pentax-pef;image/x-png;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;
+MimeType=image/jpeg;image/jpg;image/pjpeg;image/png;image/tiff;image/gif;image/x-3fr;image/x-adobe-dng;image/x-arw;image/x-bay;image/x-bmp;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-pef;image/x-pentax-pef;image/x-png;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/webp;
 Categories=Graphics;Viewer;Photography;GNOME;GTK;
 Actions=AboutDialog;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,6 +165,7 @@ vala_precompile (VALA_C ${EXEC_NAME}
     photos/PngSupport.vala
     photos/RawSupport.vala
     photos/TiffSupport.vala
+    photos/WebPSupport.vala
 
     plugins/Plugins.vala
     plugins/StandardHostInterface.vala

--- a/src/photos/PhotoFileFormat.vala
+++ b/src/photos/PhotoFileFormat.vala
@@ -77,12 +77,13 @@ public enum PhotoFileFormat {
     TIFF,
     BMP,
     GIF,
+    WEBP,
     UNKNOWN;
 
     // This is currently listed in the order of detection, that is, the file is examined from
     // left to right.  (See PhotoFileInterrogator.)
     public static PhotoFileFormat[] get_supported () {
-        return { JFIF, RAW, PNG, TIFF, BMP, GIF};
+        return { JFIF, RAW, PNG, TIFF, BMP, GIF, WEBP };
     }
 
     public static PhotoFileFormat[] get_writeable () {
@@ -161,6 +162,9 @@ public enum PhotoFileFormat {
         case GIF:
             return 5;
 
+        case WEBP:
+            return 6;
+
         case UNKNOWN:
         default:
             return -1;
@@ -187,6 +191,9 @@ public enum PhotoFileFormat {
 
         case 5:
             return GIF;
+
+        case 6:
+            return WEBP;
 
         default:
             return UNKNOWN;
@@ -266,6 +273,10 @@ public enum PhotoFileFormat {
             GifFileFormatDriver.init ();
             break;
 
+        case WEBP:
+            WebPFileFormatDriver.init ();
+            break;
+
         default:
             error ("Unsupported file format %s", this.to_string ());
         }
@@ -290,6 +301,9 @@ public enum PhotoFileFormat {
 
         case GIF:
             return GifFileFormatDriver.get_instance ();
+
+        case WEBP:
+            return WebPFileFormatDriver.get_instance ();
 
         default:
             error ("Unsupported file format %s", this.to_string ());

--- a/src/photos/WebPSupport.vala
+++ b/src/photos/WebPSupport.vala
@@ -1,0 +1,221 @@
+/*
+* Copyright (c) 2010-2013 Yorba Foundation
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+class WebPFileFormatProperties : PhotoFileFormatProperties {
+    private static string[] KNOWN_EXTENSIONS = { "webp" };
+    private static string[] KNOWN_MIME_TYPES = { "image/webp" };
+
+    private static WebPFileFormatProperties instance = null;
+
+    public static void init () {
+        instance = new WebPFileFormatProperties ();
+    }
+
+    public static WebPFileFormatProperties get_instance () {
+        return instance;
+    }
+
+    public override PhotoFileFormat get_file_format () {
+        return PhotoFileFormat.WEBP;
+    }
+
+    public override PhotoFileFormatFlags get_flags () {
+        return PhotoFileFormatFlags.NONE;
+    }
+
+    public override string get_user_visible_name () {
+        return _ ("WebP");
+    }
+
+    public override string get_default_extension () {
+        return KNOWN_EXTENSIONS[0];
+    }
+
+    public override string[] get_known_extensions () {
+        return KNOWN_EXTENSIONS;
+    }
+
+    public override string get_default_mime_type () {
+        return KNOWN_MIME_TYPES[0];
+    }
+
+    public override string[] get_mime_types () {
+        return KNOWN_MIME_TYPES;
+    }
+}
+
+public class WebPSniffer : PhotoFileSniffer {
+    private const uint8[] MAGIC_SEQUENCE_RIFF = { 0x52, 0x49, 0x46, 0x46 };
+    private const uint8[] MAGIC_SEQUENCE_WEBP = { 0x57, 0x45, 0x42, 0x50 };
+
+    public WebPSniffer (File file, PhotoFileSniffer.Options options) {
+        base (file, options);
+    }
+
+    private static bool is_webp_file (File file) throws Error {
+        FileInputStream instream = file.read (null);
+
+        uint8[] file_lead_sequence = new uint8[MAGIC_SEQUENCE_RIFF.length];
+
+        instream.read (file_lead_sequence, null);
+
+        for (int i = 0; i < MAGIC_SEQUENCE_RIFF.length; i++) {
+            if (file_lead_sequence[i] != MAGIC_SEQUENCE_RIFF[i]) {
+                return false;
+            }
+        }
+
+        // skip 4 bytes
+        instream.read (new uint8[4], null);
+
+        file_lead_sequence = new uint8[MAGIC_SEQUENCE_WEBP.length];
+
+        instream.read (file_lead_sequence, null);
+
+        for (int i = 0; i < MAGIC_SEQUENCE_WEBP.length; i++) {
+            if (file_lead_sequence[i] != MAGIC_SEQUENCE_WEBP[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override DetectedPhotoInformation? sniff () throws Error {
+        if (!is_webp_file (file))
+            return null;
+
+        DetectedPhotoInformation detected = new DetectedPhotoInformation ();
+
+        uint8[] contents;
+		file.load_contents (null, out contents, null);
+
+        WebP.BitstreamFeatures features;
+        var status = WebP.get_features (contents, out features);
+        if (status != WebP.StatusCode.OK) {
+            warning ("Error opening WebP file %s: %s", file.get_path (), status.to_string ());
+            return null;
+        }
+
+        detected.image_dim = Dimensions (features.width, features.height);
+        detected.bits_per_channel = 8;
+        detected.channels = features.has_alpha ? 4 : 3;
+
+
+        if (calc_md5)
+            detected.md5 = md5_file (file);
+
+        detected.format_name = "webp";
+        detected.file_format = PhotoFileFormat.WEBP;
+
+        return detected;
+    }
+}
+
+public class WebPReader : PhotoFileReader {
+    public WebPReader (string filepath) {
+        base (filepath, PhotoFileFormat.WEBP);
+    }
+
+    public override Gdk.Pixbuf scaled_read (Dimensions full, Dimensions scaled) throws Error {
+        return unscaled_read ().scale_simple (scaled.width, scaled.height, Gdk.InterpType.BILINEAR);
+    }
+
+    public override Gdk.Pixbuf unscaled_read () throws Error {
+        var file = get_file ();
+
+        uint8[] contents;
+		file.load_contents (null, out contents, null);
+
+        WebP.BitstreamFeatures features;
+        var status = WebP.get_features (contents, out features);
+        if (status != WebP.StatusCode.OK) {
+            throw new IOError.FAILED ("Error opening WebP file %s: %s", file.get_path (), status.to_string ());
+        }
+
+        uint8[] webp_data;
+        int width, height;
+        if (features.has_alpha) {
+            webp_data = WebP.decode_rgba (contents, out width, out height);
+        } else {
+            webp_data = WebP.decode_rgb (contents, out width, out height);
+        }
+
+        int rowstride = (features.has_alpha ? 4 : 3) * width;
+        var result = new Gdk.Pixbuf.with_unowned_data (webp_data, Gdk.Colorspace.RGB, features.has_alpha, 8, width, height, rowstride);
+
+        uint8[] png_data;
+		result.save_to_buffer (out png_data, "png");
+		var loader = new Gdk.PixbufLoader();
+		loader.write (png_data);
+		result = loader.get_pixbuf();
+		loader.close();
+
+        return result;
+    }
+
+    public override PhotoMetadata read_metadata () {
+        return new PhotoMetadata ();
+    }
+}
+
+public class WebPFileFormatDriver : PhotoFileFormatDriver {
+    private static WebPFileFormatDriver instance = null;
+
+    public static void init () {
+        instance = new WebPFileFormatDriver ();
+        WebPFileFormatProperties.init ();
+    }
+
+    public static WebPFileFormatDriver get_instance () {
+        return instance;
+    }
+
+    public override PhotoFileFormatProperties get_properties () {
+        return WebPFileFormatProperties.get_instance ();
+    }
+
+    public override PhotoFileReader create_reader (string filepath) {
+        return new WebPReader (filepath);
+    }
+
+    public override bool can_write_image () {
+        return false;
+    }
+
+    public override bool can_write_metadata () {
+        return false;
+    }
+
+    public override PhotoFileWriter? create_writer (string filepath) {
+        return null;
+    }
+
+    public override PhotoFileMetadataWriter? create_metadata_writer (string filepath) {
+        return null;
+    }
+
+    public override PhotoFileSniffer create_sniffer (File file, PhotoFileSniffer.Options options) {
+        return new WebPSniffer (file, options);
+    }
+
+    public override PhotoMetadata create_metadata () {
+        return new PhotoMetadata ();
+    }
+}

--- a/src/photos/WebPSupport.vala
+++ b/src/photos/WebPSupport.vala
@@ -159,7 +159,8 @@ public class WebPReader : PhotoFileReader {
         }
 
         int rowstride = (features.has_alpha ? 4 : 3) * width;
-        var result = new Gdk.Pixbuf.with_unowned_data (webp_data, Gdk.Colorspace.RGB, features.has_alpha, 8, width, height, rowstride);
+        var result = new Gdk.Pixbuf.with_unowned_data (webp_data, Gdk.Colorspace.RGB, features.has_alpha,
+                                                       8, width, height, rowstride);
 
         uint8[] png_data;
         result.save_to_buffer (out png_data, "png");

--- a/src/photos/WebPSupport.vala
+++ b/src/photos/WebPSupport.vala
@@ -162,11 +162,11 @@ public class WebPReader : PhotoFileReader {
         var result = new Gdk.Pixbuf.with_unowned_data (webp_data, Gdk.Colorspace.RGB, features.has_alpha, 8, width, height, rowstride);
 
         uint8[] png_data;
-		result.save_to_buffer (out png_data, "png");
-		var loader = new Gdk.PixbufLoader();
-		loader.write (png_data);
-		result = loader.get_pixbuf();
-		loader.close();
+        result.save_to_buffer (out png_data, "png");
+        var loader = new Gdk.PixbufLoader();
+        loader.write (png_data);
+        result = loader.get_pixbuf();
+        loader.close();
 
         return result;
     }

--- a/src/photos/WebPSupport.vala
+++ b/src/photos/WebPSupport.vala
@@ -1,21 +1,22 @@
-/*
-* Copyright (c) 2010-2013 Yorba Foundation
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License as published by the Free Software Foundation; either
-* version 2.1 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
 
 class WebPFileFormatProperties : PhotoFileFormatProperties {
     private static string[] KNOWN_EXTENSIONS = { "webp" };

--- a/vapi/libwebp.vapi
+++ b/vapi/libwebp.vapi
@@ -1,0 +1,53 @@
+[CCode (cheader_filename = "webp/decode.h,webp/encode.h")]
+namespace WebP {
+	public struct BitstreamFeatures {
+		public int width;
+		public int height;
+		public bool has_alpha;
+		public bool has_information;
+		public int format;
+		public int no_incremental_decoding;
+		public int rotate;
+		public int uv_sampling;
+		public uint32 pad[2];
+	}
+	
+	[CCode (cname = "VP8StatusCode", cprefix = "VP8_STATUS_")]
+	public enum StatusCode {
+		OK = 0,
+		OUT_OF_MEMORY,
+		INVALID_PARAM,
+		BITSTREAM_ERROR,
+		UNSUPPORTED_FEATURE,
+		SUSPENDED,
+		USER_ABORT,
+		NOT_ENOUGH_DATA;
+		
+		public string to_string() {
+			var strv = new string[]{
+				"VP8_STATUS_OK",
+				"VP8_STATUS_OUT_OF_MEMORY",
+				"VP8_STATUS_INVALID_PARAM",
+				"VP8_STATUS_BITSTREAM_ERROR",
+				"VP8_STATUS_UNSUPPORTED_FEATURE",
+				"VP8_STATUS_SUSPENDED",
+				"VP8_STATUS_USER_ABORT",
+				"VP8_STATUS_NOT_ENOUGH_DATA"
+			};
+			return strv[(int)this];
+		}
+	}
+	
+	[CCode (cname = "WebPGetFeatures")]
+	public static StatusCode get_features (uint8[] data, out BitstreamFeatures features);
+	
+	[CCode (cname = "WebPDecodeRGBA", array_length = false)]
+	public static uint8[] decode_rgba (uint8[] data, out int width, out int height);
+	
+	[CCode (cname = "WebPDecodeRGB", array_length = false)]
+	public static uint8[] decode_rgb (uint8[] data, out int width, out int height);
+	
+	[CCode (cname = "WebPEncodeRGB", instance_pos = -1)]
+	public static uint8[] encode_rgb ([CCode (array_length = false)] uint8[] data, int width, int height, int stride, float quality);
+}
+


### PR DESCRIPTION
Fixes #108 

Adds read-only support for WebP encoded images. Images with and without alpha channels are supported. Test files can be found here:
https://developers.google.com/speed/webp/gallery