### PR TITLE
Fix assertion crash on importing photos on HiDPI

### DIFF
--- a/src/ThumbnailCache.vala
+++ b/src/ThumbnailCache.vala
@@ -490,7 +490,7 @@ public class ThumbnailCache : Object {
     private void _import_thumbnail (ThumbnailSource source, Gdk.Pixbuf? scaled, bool force = false)
     throws Error {
         assert (scaled != null);
-        assert (Dimensions.for_pixbuf (scaled).approx_scaled (size.get_scale ()));
+        assert (Dimensions.for_pixbuf (scaled).approx_scaled (size.get_scale () * scale_factor));
 
         // if not forcing the cache operation, check if file exists and is represented in the
         // database before continuing


### PR DESCRIPTION
If a new file was added to the folder that photos was watching while it was running on a HiDPI display, it would crash due to the thumbnail generated not being the expected size.

This is a regression since adding the HiDPI thumbnail support and this resolves it.