### PR TITLE
Move CSS GResource loading to common class to both windows

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -54,6 +54,10 @@ public abstract class AppWindow : PageWindow {
 
         set_default_title ();
 
+        var css_provider = new Gtk.CssProvider ();
+        css_provider.load_from_resource ("io/elementary/photos/application.css");
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
         // restore previous size and maximization state
         if (this is LibraryWindow) {
             Config.Facade.get_instance ().get_library_window_state (out maximized, out dimensions);

--- a/src/Checkerboard/CheckerboardLayout.vala
+++ b/src/Checkerboard/CheckerboardLayout.vala
@@ -88,10 +88,6 @@ public class CheckerboardLayout : Gtk.DrawingArea {
         weak Gtk.StyleContext style_context = get_style_context ();
         style_context.add_class ("checkerboard-layout");
 
-        var css_provider = new Gtk.CssProvider ();
-        css_provider.load_from_resource ("io/elementary/photos/application.css");
-        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
         // CheckerboardItems offer tooltips
         has_tooltip = true;
     }


### PR DESCRIPTION
Fixes #130 

Turns out we do include the `.checkerboard-layout` CSS in a GResource, it was just being loaded in `CheckerboardLayout.vala` which is only used in the library window and hence won't of worked in the direct photo viewer.

Move the GResource loading code out to a window class that is a parent of both sorts of windows.