### PR TITLE
Move new GSettings init to construct

### DIFF
--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -143,9 +143,11 @@ public class LibraryWindow : AppWindow {
 
     private GLib.Settings ui_settings;
 
-    public LibraryWindow (ProgressMonitor progress_monitor) {
+    construct {
         ui_settings = new GLib.Settings (GSettingsConfigurationEngine.UI_PREFS_SCHEMA_NAME);
+    }
 
+    public LibraryWindow (ProgressMonitor progress_monitor) {
         ThumbnailCache.scale_factor = get_scale_factor ();
 
         // prep sidebar and add roots


### PR DESCRIPTION
It seems the parent class constructor is causing some attempts to get the GSettings from the last commit earlier than the object is created. Move the creation of the GSettings object to be as early as possible in `construct`.