### PR TITLE
 Port sort order settings to native GSettings 

### DIFF
--- a/src/MediaPage.vala
+++ b/src/MediaPage.vala
@@ -157,7 +157,7 @@ public abstract class MediaPage : CheckerboardPage {
     private DragAndDropHandler dnd_handler = null;
     private MediaViewTracker tracker;
     private Gtk.Menu page_context_menu;
-    private GLib.Settings ui_settings;
+    protected GLib.Settings ui_settings;
 
     construct {
         ui_settings = new GLib.Settings (GSettingsConfigurationEngine.UI_PREFS_SCHEMA_NAME);
@@ -748,9 +748,15 @@ public abstract class MediaPage : CheckerboardPage {
         ui_settings.set_boolean ("display-photo-tags", display);
     }
 
-    protected abstract void get_config_photos_sort (out bool sort_order, out int sort_by);
+    protected virtual void get_config_photos_sort (out bool sort_order, out int sort_by) {
+        sort_order = ui_settings.get_boolean ("library-photos-sort-ascending");
+        sort_by = ui_settings.get_int ("library-photos-sort-by");
+    }
 
-    protected abstract void set_config_photos_sort (bool sort_order, int sort_by);
+    protected virtual void set_config_photos_sort (bool sort_order, int sort_by) {
+        ui_settings.set_boolean ("library-photos-sort-ascending", sort_order);
+        ui_settings.set_int ("library-photos-sort-by", sort_by);
+    }
 
     public virtual void on_sort_changed () {
         int sort_by = get_menu_sort_by ();

--- a/src/config/ConfigurationInterfaces.vala
+++ b/src/config/ConfigurationInterfaces.vala
@@ -42,9 +42,6 @@ public enum ConfigurableProperty {
     DIRECT_WINDOW_HEIGHT,
     DIRECT_WINDOW_MAXIMIZE,
     DIRECT_WINDOW_WIDTH,
-    EVENT_PHOTOS_SORT_ASCENDING,
-    EVENT_PHOTOS_SORT_BY,
-    EVENTS_SORT_ASCENDING,
     EXTERNAL_PHOTO_APP,
     EXTERNAL_RAW_APP,
     HIDE_PHOTOS_ALREADY_IMPORTED,
@@ -55,8 +52,6 @@ public enum ConfigurableProperty {
     LAST_CROP_WIDTH,
     LAST_USED_SERVICE,
     LAST_USED_DATAIMPORTS_SERVICE,
-    LIBRARY_PHOTOS_SORT_ASCENDING,
-    LIBRARY_PHOTOS_SORT_BY,
     LIBRARY_WINDOW_HEIGHT,
     LIBRARY_WINDOW_MAXIMIZE,
     LIBRARY_WINDOW_WIDTH,
@@ -114,15 +109,6 @@ public enum ConfigurableProperty {
         case DIRECT_WINDOW_WIDTH:
             return "DIRECT_WINDOW_WIDTH";
 
-        case EVENT_PHOTOS_SORT_ASCENDING:
-            return "EVENT_PHOTOS_SORT_ASCENDING";
-
-        case EVENT_PHOTOS_SORT_BY:
-            return "EVENT_PHOTOS_SORT_BY";
-
-        case EVENTS_SORT_ASCENDING:
-            return "EVENTS_SORT_ASCENDING";
-
         case EXTERNAL_PHOTO_APP:
             return "EXTERNAL_PHOTO_APP";
 
@@ -152,12 +138,6 @@ public enum ConfigurableProperty {
 
         case LAST_USED_DATAIMPORTS_SERVICE:
             return "LAST_USED_DATAIMPORTS_SERVICE";
-
-        case LIBRARY_PHOTOS_SORT_ASCENDING:
-            return "LIBRARY_PHOTOS_SORT_ASCENDING";
-
-        case LIBRARY_PHOTOS_SORT_BY:
-            return "LIBRARY_PHOTOS_SORT_BY";
 
         case LIBRARY_WINDOW_HEIGHT:
             return "LIBRARY_WINDOW_HEIGHT";
@@ -273,7 +253,6 @@ public abstract class ConfigurationFacade : Object {
 
     public signal void auto_import_from_library_changed ();
     public signal void commit_metadata_to_masters_changed ();
-    public signal void events_sort_ascending_changed ();
     public signal void external_app_changed ();
     public signal void import_directory_changed ();
 
@@ -293,10 +272,6 @@ public abstract class ConfigurationFacade : Object {
 
         case ConfigurableProperty.COMMIT_METADATA_TO_MASTERS:
             commit_metadata_to_masters_changed ();
-            break;
-
-        case ConfigurableProperty.EVENTS_SORT_ASCENDING:
-            events_sort_ascending_changed ();
             break;
 
         case ConfigurableProperty.EXTERNAL_PHOTO_APP:
@@ -468,54 +443,6 @@ public abstract class ConfigurationFacade : Object {
                                             dimensions.height);
         } catch (ConfigurationError err) {
             on_configuration_error (err);
-        }
-    }
-
-    //
-    // event photos sort
-    //
-    public virtual void get_event_photos_sort (out bool sort_order, out int sort_by) {
-        sort_order = false;
-        sort_by = 2;
-        try {
-            sort_order = get_engine ().get_bool_property (
-                             ConfigurableProperty.EVENT_PHOTOS_SORT_ASCENDING);
-            sort_by = get_engine ().get_int_property (ConfigurableProperty.EVENT_PHOTOS_SORT_BY);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-        }
-    }
-
-    public virtual void set_event_photos_sort (bool sort_order, int sort_by) {
-        try {
-            get_engine ().set_bool_property (ConfigurableProperty.EVENT_PHOTOS_SORT_ASCENDING,
-                                             sort_order);
-            get_engine ().set_int_property (ConfigurableProperty.EVENT_PHOTOS_SORT_BY,
-                                            sort_by);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-        }
-    }
-
-    //
-    // events sort ascending
-    //
-    public virtual bool get_events_sort_ascending () {
-        try {
-            return get_engine ().get_bool_property (ConfigurableProperty.EVENTS_SORT_ASCENDING);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-
-            return false;
-        }
-    }
-
-    public virtual void set_events_sort_ascending (bool sort) {
-        try {
-            get_engine ().set_bool_property (ConfigurableProperty.EVENTS_SORT_ASCENDING, sort);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-            return;
         }
     }
 
@@ -759,32 +686,6 @@ public abstract class ConfigurationFacade : Object {
     public virtual void set_last_used_dataimports_service (string service_name) {
         try {
             get_engine ().set_string_property (ConfigurableProperty.LAST_USED_DATAIMPORTS_SERVICE, service_name);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-        }
-    }
-
-    //
-    // library photos sort
-    //
-    public virtual void get_library_photos_sort (out bool sort_order, out int sort_by) {
-        sort_order = false;
-        sort_by = 2;
-        try {
-            sort_order = get_engine ().get_bool_property (
-                             ConfigurableProperty.LIBRARY_PHOTOS_SORT_ASCENDING);
-            sort_by = get_engine ().get_int_property (ConfigurableProperty.LIBRARY_PHOTOS_SORT_BY);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-        }
-    }
-
-    public virtual void set_library_photos_sort (bool sort_order, int sort_by) {
-        try {
-            get_engine ().set_bool_property (ConfigurableProperty.LIBRARY_PHOTOS_SORT_ASCENDING,
-                                             sort_order);
-            get_engine ().set_int_property (ConfigurableProperty.LIBRARY_PHOTOS_SORT_BY,
-                                            sort_by);
         } catch (ConfigurationError err) {
             on_configuration_error (err);
         }

--- a/src/config/GSettingsEngine.vala
+++ b/src/config/GSettingsEngine.vala
@@ -54,9 +54,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
         schema_names[ConfigurableProperty.DIRECT_WINDOW_HEIGHT] = WINDOW_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.DIRECT_WINDOW_MAXIMIZE] = WINDOW_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.DIRECT_WINDOW_WIDTH] = WINDOW_PREFS_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.EVENT_PHOTOS_SORT_ASCENDING] = UI_PREFS_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.EVENT_PHOTOS_SORT_BY] = UI_PREFS_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.EVENTS_SORT_ASCENDING] = UI_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.EXTERNAL_PHOTO_APP] = EDITING_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.EXTERNAL_RAW_APP] = EDITING_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.HIDE_PHOTOS_ALREADY_IMPORTED] = UI_PREFS_SCHEMA_NAME;
@@ -67,8 +64,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
         schema_names[ConfigurableProperty.LAST_CROP_WIDTH] = CROP_SCHEMA_NAME;
         schema_names[ConfigurableProperty.LAST_USED_SERVICE] = SHARING_SCHEMA_NAME;
         schema_names[ConfigurableProperty.LAST_USED_DATAIMPORTS_SERVICE] = IMPORTING_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.LIBRARY_PHOTOS_SORT_ASCENDING] = UI_PREFS_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.LIBRARY_PHOTOS_SORT_BY] = UI_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.LIBRARY_WINDOW_HEIGHT] = WINDOW_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.LIBRARY_WINDOW_MAXIMIZE] = WINDOW_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.LIBRARY_WINDOW_WIDTH] = WINDOW_PREFS_SCHEMA_NAME;
@@ -105,9 +100,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
         key_names[ConfigurableProperty.DIRECT_WINDOW_HEIGHT] = "direct-height";
         key_names[ConfigurableProperty.DIRECT_WINDOW_MAXIMIZE] = "direct-maximize";
         key_names[ConfigurableProperty.DIRECT_WINDOW_WIDTH] = "direct-width";
-        key_names[ConfigurableProperty.EVENT_PHOTOS_SORT_ASCENDING] = "event-photos-sort-ascending";
-        key_names[ConfigurableProperty.EVENT_PHOTOS_SORT_BY] = "event-photos-sort-by";
-        key_names[ConfigurableProperty.EVENTS_SORT_ASCENDING] = "events-sort-ascending";
         key_names[ConfigurableProperty.EXTERNAL_PHOTO_APP] = "external-photo-editor";
         key_names[ConfigurableProperty.EXTERNAL_RAW_APP] = "external-raw-editor";
         key_names[ConfigurableProperty.HIDE_PHOTOS_ALREADY_IMPORTED] = "hide-photos-already-imported";
@@ -118,8 +110,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
         key_names[ConfigurableProperty.LAST_CROP_WIDTH] = "last-crop-width";
         key_names[ConfigurableProperty.LAST_USED_SERVICE] = "last-used-service";
         key_names[ConfigurableProperty.LAST_USED_DATAIMPORTS_SERVICE] = "last-used-dataimports-service";
-        key_names[ConfigurableProperty.LIBRARY_PHOTOS_SORT_ASCENDING] = "library-photos-sort-ascending";
-        key_names[ConfigurableProperty.LIBRARY_PHOTOS_SORT_BY] = "library-photos-sort-by";
         key_names[ConfigurableProperty.LIBRARY_WINDOW_HEIGHT] = "library-height";
         key_names[ConfigurableProperty.LIBRARY_WINDOW_MAXIMIZE] = "library-maximize";
         key_names[ConfigurableProperty.LIBRARY_WINDOW_WIDTH] = "library-width";

--- a/src/events/Branch.vala
+++ b/src/events/Branch.vala
@@ -34,7 +34,6 @@ public class Events.Branch : Sidebar.Branch {
         }
         set {
             _sort_ascending = value;
-            warning ("sort_ascending changed");
             reorder_all ();
         }
     }

--- a/src/events/Branch.vala
+++ b/src/events/Branch.vala
@@ -27,12 +27,27 @@ public class Events.Branch : Sidebar.Branch {
     // NOTE: Because the comparators must be static methods (due to CompareFunc's stupid impl.)
     // and there's an assumption that only one Events.Branch is ever created, this is a static
     // member but it's modified by instance methods.
-    private static bool sort_ascending = false;
+    private static bool _sort_ascending = false;
+    private bool sort_ascending {
+        get {
+            return _sort_ascending;
+        }
+        set {
+            _sort_ascending = value;
+            warning ("sort_ascending changed");
+            reorder_all ();
+        }
+    }
 
     private Gee.HashMap<Event, Events.EventEntry> entry_map = new Gee.HashMap <
     Event, Events.EventEntry > ();
     private Events.UndatedDirectoryEntry undated_entry = new Events.UndatedDirectoryEntry ();
     private Events.NoEventEntry no_event_entry = new Events.NoEventEntry ();
+    private GLib.Settings ui_settings;
+
+    construct {
+        ui_settings = new GLib.Settings (GSettingsConfigurationEngine.UI_PREFS_SCHEMA_NAME);
+    }
 
     public Branch () {
         base (new Events.MasterDirectoryEntry (), Sidebar.Branch.Options.STARTUP_EXPAND_TO_FIRST_CHILD,
@@ -49,16 +64,19 @@ public class Events.Branch : Sidebar.Branch {
         Event.global.items_altered.connect (on_events_altered);
         Event.global.no_event_collection_altered.connect (on_no_event_collection_altered);
 
-        // monitor sorting criteria (see note at sort_ascending about this)
-        Config.Facade.get_instance ().events_sort_ascending_changed.connect (on_config_changed);
+        ui_settings.changed.connect ((key) => {
+            if (key == "events-sort-ascending") {
+                sort_ascending = ui_settings.get_boolean ("events-sort-ascending");
+            }
+        });
+
+        sort_ascending = ui_settings.get_boolean ("events-sort-ascending");
     }
 
     ~Branch () {
         Event.global.contents_altered.disconnect (on_events_added_removed);
         Event.global.items_altered.disconnect (on_events_altered);
         Event.global.no_event_collection_altered.disconnect (on_no_event_collection_altered);
-
-        Config.Facade.get_instance ().events_sort_ascending_changed.disconnect (on_config_changed);
     }
 
     internal static void init () {
@@ -67,8 +85,6 @@ public class Events.Branch : Sidebar.Branch {
         events_icon = new ThemedIcon (Resources.ICON_EVENTS);
         single_event_icon = new ThemedIcon (Resources.ICON_ONE_EVENT);
         no_event_icon = new ThemedIcon (Resources.ICON_NO_EVENT);
-
-        sort_ascending = Config.Facade.get_instance ().get_events_sort_ascending ();
     }
 
     internal static void terminate () {
@@ -104,7 +120,7 @@ public class Events.Branch : Sidebar.Branch {
         else if (b is Events.NoEventEntry)
             return -1;
 
-        if (!sort_ascending) {
+        if (!_sort_ascending) {
             Sidebar.Entry swap = a;
             a = b;
             b = swap;
@@ -121,7 +137,7 @@ public class Events.Branch : Sidebar.Branch {
         if (a == b)
             return 0;
 
-        if (!sort_ascending) {
+        if (!_sort_ascending) {
             Sidebar.Entry swap = a;
             a = b;
             b = swap;
@@ -138,7 +154,7 @@ public class Events.Branch : Sidebar.Branch {
         if (a == b)
             return 0;
 
-        if (!sort_ascending) {
+        if (!_sort_ascending) {
             Sidebar.Entry swap = a;
             a = b;
             b = swap;
@@ -162,7 +178,7 @@ public class Events.Branch : Sidebar.Branch {
         if (a == b)
             return 0;
 
-        if (!sort_ascending) {
+        if (!_sort_ascending) {
             Sidebar.Entry swap = a;
             a = b;
             b = swap;
@@ -180,13 +196,6 @@ public class Events.Branch : Sidebar.Branch {
 
     public Events.EventEntry? get_entry_for_event (Event event) {
         return entry_map.get (event);
-    }
-
-    private void on_config_changed () {
-        bool value = Config.Facade.get_instance ().get_events_sort_ascending ();
-
-        sort_ascending = value;
-        reorder_all ();
     }
 
     private void on_events_added_removed (Gee.Iterable<DataObject>? added,

--- a/src/events/EventPage.vala
+++ b/src/events/EventPage.vala
@@ -97,11 +97,13 @@ public class EventPage : CollectionPage {
     }
 
     protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_event_photos_sort (out sort_order, out sort_by);
+        sort_order = ui_settings.get_boolean ("event-photos-sort-ascending");
+        sort_by = ui_settings.get_int ("event-photos-sort-by");
     }
 
     protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_event_photos_sort (sort_order, sort_by);
+        ui_settings.set_boolean ("event-photos-sort-ascending", sort_order);
+        ui_settings.set_int ("event-photos-sort-by", sort_by);
     }
 
     private void on_events_altered (Gee.Map<DataObject, Alteration> map) {
@@ -170,11 +172,13 @@ public class NoEventPage : CollectionPage {
     }
 
     protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_event_photos_sort (out sort_order, out sort_by);
+        sort_order = ui_settings.get_boolean ("event-photos-sort-ascending");
+        sort_by = ui_settings.get_int ("event-photos-sort-by");
     }
 
     protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_event_photos_sort (sort_order, sort_by);
+        ui_settings.set_boolean ("event-photos-sort-ascending", sort_order);
+        ui_settings.set_int ("event-photos-sort-by", sort_by);
     }
 }
 

--- a/src/events/EventsDirectoryPage.vala
+++ b/src/events/EventsDirectoryPage.vala
@@ -67,7 +67,7 @@ public abstract class EventsDirectoryPage : CheckerboardPage {
         base (page_name);
 
         // set comparator before monitoring source collection, to prevent a re-sort
-        get_view ().set_comparator (get_event_comparator (Config.Facade.get_instance ().get_events_sort_ascending ()),
+        get_view ().set_comparator (get_event_comparator (ui_settings.get_boolean ("events-sort-ascending")),
                                     event_comparator_predicate);
         get_view ().monitor_source_collection (Event.global, view_manager, null, initial_events);
 

--- a/src/library/Branch.vala
+++ b/src/library/Branch.vala
@@ -170,14 +170,6 @@ public class Library.MainPage : CollectionPage {
             get_view ().monitor_source_collection (sources, new CollectionViewManager (this), null, null, monitor);
     }
 
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
-
     public override string get_back_name () {
         return _("All Photos");
     }

--- a/src/library/FlaggedPage.vala
+++ b/src/library/FlaggedPage.vala
@@ -51,14 +51,6 @@ public class FlaggedPage : CollectionPage {
             get_view ().monitor_source_collection (sources, view_manager, prereq);
     }
 
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
-
     public override SearchViewFilter get_search_view_filter () {
         return search_filter;
     }

--- a/src/library/LastImportPage.vala
+++ b/src/library/LastImportPage.vala
@@ -80,13 +80,5 @@ public class LastImportPage : CollectionPage {
                                                   last_import_id), last_import_alteration);
         }
     }
-
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
 }
 

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -705,8 +705,7 @@ public class LibraryWindow : AppWindow {
     private void on_events_sort_changed (Gtk.Action action, Gtk.Action c) {
         Gtk.RadioAction current = (Gtk.RadioAction) c;
 
-        Config.Facade.get_instance ().set_events_sort_ascending (
-            current.current_value == SORT_EVENTS_ORDER_ASCENDING);
+        ui_settings.set_boolean ("events-sort-ascending", current.current_value == SORT_EVENTS_ORDER_ASCENDING);
     }
 
     private void on_preferences () {
@@ -992,7 +991,7 @@ public class LibraryWindow : AppWindow {
         // Ticket #3321 - Event sorting order wasn't saving on exit.
         // Instead of calling set_active against one of the toggles, call
         // set_current_value against the entire radio group...
-        int event_sort_val = Config.Facade.get_instance ().get_events_sort_ascending () ? SORT_EVENTS_ORDER_ASCENDING :
+        int event_sort_val = ui_settings.get_boolean ("events-sort-ascending") ? SORT_EVENTS_ORDER_ASCENDING :
                              SORT_EVENTS_ORDER_DESCENDING;
 
         sort_events_action.set_current_value (event_sort_val);

--- a/src/library/PhotosPage.vala
+++ b/src/library/PhotosPage.vala
@@ -73,13 +73,6 @@ public class Library.PhotosPage : CollectionPage {
     private ViewManager view_manager;
     private PhotosSearchViewFilter search_filter = new PhotosSearchViewFilter ();
 
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
     public override SearchViewFilter get_search_view_filter () {
         return search_filter;
     }

--- a/src/library/RawsPage.vala
+++ b/src/library/RawsPage.vala
@@ -73,13 +73,6 @@ public class Library.RawsPage : CollectionPage {
     private ViewManager view_manager;
     private RawsSearchViewFilter search_filter = new RawsSearchViewFilter ();
 
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
     public override SearchViewFilter get_search_view_filter () {
         return search_filter;
     }

--- a/src/library/VideosPage.vala
+++ b/src/library/VideosPage.vala
@@ -84,13 +84,6 @@ public class Library.VideosPage : CollectionPage {
     private ViewManager view_manager;
     private VideosSearchViewFilter search_filter = new VideosSearchViewFilter ();
 
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
     public override SearchViewFilter get_search_view_filter () {
         return search_filter;
     }

--- a/src/searches/SavedSearchPage.vala
+++ b/src/searches/SavedSearchPage.vala
@@ -71,14 +71,6 @@ public class SavedSearchPage : CollectionPage {
         return page_sidebar_menu;
     }
 
-    protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_library_photos_sort (out sort_order, out sort_by);
-    }
-
-    protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_library_photos_sort (sort_order, sort_by);
-    }
-
     protected override Gtk.ActionEntry[] init_collect_action_entries () {
         Gtk.ActionEntry[] actions = base.init_collect_action_entries ();
 

--- a/src/tags/TagPage.vala
+++ b/src/tags/TagPage.vala
@@ -69,11 +69,13 @@ public class TagPage : CollectionPage {
     }
 
     protected override void get_config_photos_sort (out bool sort_order, out int sort_by) {
-        Config.Facade.get_instance ().get_event_photos_sort (out sort_order, out sort_by);
+        sort_order = ui_settings.get_boolean ("event-photos-sort-ascending");
+        sort_by = ui_settings.get_int ("event-photos-sort-by");
     }
 
     protected override void set_config_photos_sort (bool sort_order, int sort_by) {
-        Config.Facade.get_instance ().set_event_photos_sort (sort_order, sort_by);
+        ui_settings.set_boolean ("event-photos-sort-ascending", sort_order);
+        ui_settings.set_int ("event-photos-sort-by", sort_by);
     }
 
     protected override Gtk.ActionEntry[] init_collect_action_entries () {


### PR DESCRIPTION
Also move the most commonly used versions of the `get_config_photos_sort` and `set_config_photos_sort` methods to a parent class instead of repeating it many times.