### PR TITLE
Remove editing GSettings

### DIFF
--- a/schemas/org.pantheon.photos.gschema.xml
+++ b/schemas/org.pantheon.photos.gschema.xml
@@ -13,7 +13,6 @@
     <child name="slideshow" schema="org.pantheon.photos.preferences.slideshow" />
     <child name="window" schema="org.pantheon.photos.preferences.window" />
     <child name="files" schema="org.pantheon.photos.preferences.files" />
-    <child name="editing" schema="org.pantheon.photos.preferences.editing" />
 </schema>
 
 <schema id="org.pantheon.photos.preferences.ui" path="/org/pantheon/photos/preferences/ui/">
@@ -249,20 +248,6 @@
         <default>1</default>
         <summary>Most-recently-used crop custom aspect ratio's denominator.</summary>
         <description>A nonzero, positive integer representing the height part of the last custom crop ratio the user entered.</description>
-    </key>
-</schema>
-
-<schema id="org.pantheon.photos.preferences.editing" path="/org/pantheon/photos/preferences/editing/">
-    <key name="external-photo-editor" type="s">
-        <default>""</default>
-        <summary>external photo editor</summary>
-        <description>External application used to edit photos.</description>
-    </key>
-    
-    <key name="external-raw-editor" type="s">
-        <default>""</default>
-        <summary>external raw editor</summary>
-        <description>External application used to edit RAW photos.</description>
     </key>
 </schema>
 

--- a/src/CollectionPage.vala
+++ b/src/CollectionPage.vala
@@ -49,6 +49,11 @@ public abstract class CollectionPage : MediaPage {
     private Gtk.Menu contractor_menu;
     private Gtk.ToolButton rotate_button;
     private Gtk.ToolButton flip_button;
+    private GLib.Settings editing_settings;
+
+    construct {
+        editing_settings = new GLib.Settings (GSettingsConfigurationEngine.EDITING_PREFS_SCHEMA_NAME);
+    }
 
     public CollectionPage (string page_name) {
         base (page_name);
@@ -590,7 +595,7 @@ public abstract class CollectionPage : MediaPage {
         if (activator == CheckerboardPage.Activator.MOUSE) {
             if (modifiers.super_pressed)
                 //last used
-                on_open_with (Config.Facade.get_instance ().get_external_photo_app ());
+                on_open_with (editing_settings.get_string ("external-photo-editor"));
             else
                 LibraryWindow.get_app ().switch_to_photo_page (this, photo);
         } else if (activator == CheckerboardPage.Activator.KEYBOARD) {

--- a/src/CollectionPage.vala
+++ b/src/CollectionPage.vala
@@ -49,11 +49,6 @@ public abstract class CollectionPage : MediaPage {
     private Gtk.Menu contractor_menu;
     private Gtk.ToolButton rotate_button;
     private Gtk.ToolButton flip_button;
-    private GLib.Settings editing_settings;
-
-    construct {
-        editing_settings = new GLib.Settings (GSettingsConfigurationEngine.EDITING_PREFS_SCHEMA_NAME);
-    }
 
     public CollectionPage (string page_name) {
         base (page_name);
@@ -573,8 +568,7 @@ public abstract class CollectionPage : MediaPage {
     // Enter = switch to PhotoPage
     // Ctrl + Enter = open in external editor (handled with accelerators)
     // Shift + Ctrl + Enter = open in external RAW editor (handled with accelerators)
-    protected override void on_item_activated (CheckerboardItem item, CheckerboardPage.Activator
-            activator, CheckerboardPage.KeyboardModifiers modifiers) {
+    protected override void on_item_activated (CheckerboardItem item) {
         Thumbnail thumbnail = (Thumbnail) item;
 
         // none of the fancy Super, Ctrl, Shift, etc., keyboard accelerators apply to videos,
@@ -589,19 +583,8 @@ public abstract class CollectionPage : MediaPage {
         if (photo == null)
             return;
 
-        // switch to full-page view or open in external editor
         debug ("activating %s", photo.to_string ());
-
-        if (activator == CheckerboardPage.Activator.MOUSE) {
-            if (modifiers.super_pressed)
-                //last used
-                on_open_with (editing_settings.get_string ("external-photo-editor"));
-            else
-                LibraryWindow.get_app ().switch_to_photo_page (this, photo);
-        } else if (activator == CheckerboardPage.Activator.KEYBOARD) {
-            if (!modifiers.shift_pressed && !modifiers.ctrl_pressed)
-                LibraryWindow.get_app ().switch_to_photo_page (this, photo);
-        }
+        LibraryWindow.get_app ().switch_to_photo_page (this, photo);
     }
 
     protected override bool on_app_key_pressed (Gdk.EventKey event) {

--- a/src/Page.vala
+++ b/src/Page.vala
@@ -1214,8 +1214,7 @@ public abstract class CheckerboardPage : Page {
         return _ ("No photos/videos found");
     }
 
-    protected virtual void on_item_activated (CheckerboardItem item, Activator activator,
-            KeyboardModifiers modifiers) {
+    protected virtual void on_item_activated (CheckerboardItem item) {
     }
 
     public CheckerboardLayout get_checkerboard_layout () {
@@ -1387,8 +1386,7 @@ public abstract class CheckerboardPage : Page {
         case "Return":
         case "KP_Enter":
             if (get_view ().get_selected_count () == 1)
-                on_item_activated ((CheckerboardItem) get_view ().get_selected_at (0),
-                                   Activator.KEYBOARD, KeyboardModifiers (this));
+                on_item_activated ((CheckerboardItem) get_view ().get_selected_at (0));
             else
                 handled = false;
             break;
@@ -1534,7 +1532,7 @@ public abstract class CheckerboardPage : Page {
 
         // if the item was activated in the double-click, report it now
         if (activated_item != null) {
-            on_item_activated (activated_item, Activator.MOUSE, KeyboardModifiers (this));
+            on_item_activated (activated_item);
             activated_item = null;
 
             return true;

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -256,6 +256,8 @@ public abstract class Photo : PhotoSource, Dateable {
 
     protected bool can_rotate_now = true;
 
+    private GLib.Settings editing_settings;
+
     // The first time we have to run the pipeline on an image, we'll precache
     // a copy of the unscaled, unmodified version; this allows us to operate
     // directly on the image data quickly without re-fetching it at the top
@@ -327,6 +329,10 @@ public abstract class Photo : PhotoSource, Dateable {
     //
     // See BackingFetchMode for more details.
     public virtual signal void source_reimported (PhotoMetadata? metadata) {
+    }
+
+    construct {
+        editing_settings = new GLib.Settings (GSettingsConfigurationEngine.EDITING_PREFS_SCHEMA_NAME);
     }
 
     // The key to this implementation is that multiple instances of Photo with the
@@ -3688,8 +3694,7 @@ public abstract class Photo : PhotoSource, Dateable {
 
     // Opens with Ufraw, etc.
     public void open_with_raw_external_editor (string external_editor) throws Error {
-        //store last used
-        Config.Facade.get_instance ().set_external_raw_app (external_editor);
+        editing_settings.set_string ("external-raw-editor", external_editor);
         launch_editor (get_master_file (), get_master_file_format (), external_editor);
     }
 
@@ -3697,8 +3702,7 @@ public abstract class Photo : PhotoSource, Dateable {
     public void open_with_external_editor (string external_editor) throws Error {
         File modified_file = get_modified_file ();
 
-        //store last used
-        Config.Facade.get_instance ().set_external_photo_app (external_editor);
+        editing_settings.set_string ("external-photo-editor", external_editor);
         launch_editor (modified_file, get_file_format (), external_editor);
     }
 

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -256,8 +256,6 @@ public abstract class Photo : PhotoSource, Dateable {
 
     protected bool can_rotate_now = true;
 
-    private GLib.Settings editing_settings;
-
     // The first time we have to run the pipeline on an image, we'll precache
     // a copy of the unscaled, unmodified version; this allows us to operate
     // directly on the image data quickly without re-fetching it at the top
@@ -329,10 +327,6 @@ public abstract class Photo : PhotoSource, Dateable {
     //
     // See BackingFetchMode for more details.
     public virtual signal void source_reimported (PhotoMetadata? metadata) {
-    }
-
-    construct {
-        editing_settings = new GLib.Settings (GSettingsConfigurationEngine.EDITING_PREFS_SCHEMA_NAME);
     }
 
     // The key to this implementation is that multiple instances of Photo with the
@@ -3694,15 +3688,12 @@ public abstract class Photo : PhotoSource, Dateable {
 
     // Opens with Ufraw, etc.
     public void open_with_raw_external_editor (string external_editor) throws Error {
-        editing_settings.set_string ("external-raw-editor", external_editor);
         launch_editor (get_master_file (), get_master_file_format (), external_editor);
     }
 
     // Opens with GIMP, etc.
     public void open_with_external_editor (string external_editor) throws Error {
         File modified_file = get_modified_file ();
-
-        editing_settings.set_string ("external-photo-editor", external_editor);
         launch_editor (modified_file, get_file_format (), external_editor);
     }
 

--- a/src/config/ConfigurationInterfaces.vala
+++ b/src/config/ConfigurationInterfaces.vala
@@ -39,8 +39,6 @@ public enum ConfigurableProperty {
     DESKTOP_BACKGROUND_MODE,
     DIRECTORY_PATTERN,
     DIRECTORY_PATTERN_CUSTOM,
-    EXTERNAL_PHOTO_APP,
-    EXTERNAL_RAW_APP,
     IMPORT_DIR,
     RAW_DEVELOPER_DEFAULT,
     USE_LOWERCASE_FILENAMES,
@@ -68,12 +66,6 @@ public enum ConfigurableProperty {
 
         case DIRECTORY_PATTERN_CUSTOM:
             return "DIRECTORY_PATTERN_CUSTOM";
-
-        case EXTERNAL_PHOTO_APP:
-            return "EXTERNAL_PHOTO_APP";
-
-        case EXTERNAL_RAW_APP:
-            return "EXTERNAL_RAW_APP";
 
         case IMPORT_DIR:
             return "IMPORT_DIR";
@@ -129,7 +121,6 @@ public abstract class ConfigurationFacade : Object {
 
     public signal void auto_import_from_library_changed ();
     public signal void commit_metadata_to_masters_changed ();
-    public signal void external_app_changed ();
     public signal void import_directory_changed ();
 
     protected ConfigurationFacade (ConfigurationEngine engine) {
@@ -148,11 +139,6 @@ public abstract class ConfigurationFacade : Object {
 
         case ConfigurableProperty.COMMIT_METADATA_TO_MASTERS:
             commit_metadata_to_masters_changed ();
-            break;
-
-        case ConfigurableProperty.EXTERNAL_PHOTO_APP:
-        case ConfigurableProperty.EXTERNAL_RAW_APP:
-            external_app_changed ();
             break;
 
         case ConfigurableProperty.IMPORT_DIR:
@@ -291,52 +277,6 @@ public abstract class ConfigurationFacade : Object {
             get_engine ().set_string_property (ConfigurableProperty.DIRECTORY_PATTERN_CUSTOM, s);
         } catch (ConfigurationError err) {
             on_configuration_error (err);
-        }
-    }
-
-    //
-    // external photo app
-    //
-    public virtual string get_external_photo_app () {
-        try {
-            return get_engine ().get_string_property (ConfigurableProperty.EXTERNAL_PHOTO_APP);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-
-            return "";
-        }
-    }
-
-    public virtual void set_external_photo_app (string external_photo_app) {
-        try {
-            get_engine ().set_string_property (ConfigurableProperty.EXTERNAL_PHOTO_APP,
-                                               external_photo_app);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-            return;
-        }
-    }
-
-    //
-    // external raw app
-    //
-    public virtual string get_external_raw_app () {
-        try {
-            return get_engine ().get_string_property (ConfigurableProperty.EXTERNAL_RAW_APP);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-
-            return "";
-        }
-    }
-
-    public virtual void set_external_raw_app (string external_raw_app) {
-        try {
-            get_engine ().set_string_property (ConfigurableProperty.EXTERNAL_RAW_APP,
-                                               external_raw_app);
-        } catch (ConfigurationError err) {
-            on_configuration_error (err);
-            return;
         }
     }
 

--- a/src/config/GSettingsEngine.vala
+++ b/src/config/GSettingsEngine.vala
@@ -50,8 +50,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
         schema_names[ConfigurableProperty.DESKTOP_BACKGROUND_MODE] = SYSTEM_DESKTOP_SCHEMA_NAME;
         schema_names[ConfigurableProperty.DIRECTORY_PATTERN] = FILES_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.DIRECTORY_PATTERN_CUSTOM] = FILES_PREFS_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.EXTERNAL_PHOTO_APP] = EDITING_PREFS_SCHEMA_NAME;
-        schema_names[ConfigurableProperty.EXTERNAL_RAW_APP] = EDITING_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.IMPORT_DIR] = FILES_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.RAW_DEVELOPER_DEFAULT] = FILES_PREFS_SCHEMA_NAME;
         schema_names[ConfigurableProperty.USE_LOWERCASE_FILENAMES] = FILES_PREFS_SCHEMA_NAME;
@@ -65,8 +63,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
         key_names[ConfigurableProperty.DESKTOP_BACKGROUND_MODE] = "picture-options";
         key_names[ConfigurableProperty.DIRECTORY_PATTERN] = "directory-pattern";
         key_names[ConfigurableProperty.DIRECTORY_PATTERN_CUSTOM] = "directory-pattern-custom";
-        key_names[ConfigurableProperty.EXTERNAL_PHOTO_APP] = "external-photo-editor";
-        key_names[ConfigurableProperty.EXTERNAL_RAW_APP] = "external-raw-editor";
         key_names[ConfigurableProperty.IMPORT_DIR] = "import-dir";
         key_names[ConfigurableProperty.RAW_DEVELOPER_DEFAULT] = "raw-developer-default";
         key_names[ConfigurableProperty.USE_LOWERCASE_FILENAMES] = "use-lowercase-filenames";

--- a/src/config/GSettingsEngine.vala
+++ b/src/config/GSettingsEngine.vala
@@ -24,7 +24,6 @@ public class GSettingsConfigurationEngine : ConfigurationEngine, GLib.Object {
     public const string SLIDESHOW_PREFS_SCHEMA_NAME = PREFS_SCHEMA_NAME + ".slideshow";
     public const string WINDOW_PREFS_SCHEMA_NAME =  PREFS_SCHEMA_NAME + ".window";
     public const string FILES_PREFS_SCHEMA_NAME = PREFS_SCHEMA_NAME + ".files";
-    public const string EDITING_PREFS_SCHEMA_NAME = PREFS_SCHEMA_NAME + ".editing";
     public const string VIDEO_SCHEMA_NAME = ROOT_SCHEMA_NAME + ".video";
     public const string PRINTING_SCHEMA_NAME = ROOT_SCHEMA_NAME + ".printing";
     public const string SHARING_SCHEMA_NAME = ROOT_SCHEMA_NAME + ".sharing";

--- a/src/events/EventsDirectoryPage.vala
+++ b/src/events/EventsDirectoryPage.vala
@@ -268,8 +268,7 @@ public abstract class EventsDirectoryPage : CheckerboardPage {
         return _ ("No events found");
     }
 
-    public override void on_item_activated (CheckerboardItem item, CheckerboardPage.Activator
-                                            activator, CheckerboardPage.KeyboardModifiers modifiers) {
+    public override void on_item_activated (CheckerboardItem item) {
         EventDirectoryItem event = (EventDirectoryItem) item;
         LibraryWindow.get_app ().switch_to_event (event.event);
     }


### PR DESCRIPTION
I was porting these settings to native GSettings as I've been doing with the others. When it came to testing them, I noticed that they weren't really being used.

I think the original intention of these was that once you'd right clicked an image and said "Open With", it stored that application in GSettings. Then it looked like at some point in the past, it was possible to hold super and double click an image in your library and it would open in that "default" editor stored in GSettings.

That's been broken in master for who knows how long and seems like a bit of a hidden/confusing feature anyway. So I propose removing the GSettings and associated code altogether as per this branch.