### PR TITLE
Don't bind null pointers to database queries

### DIFF
--- a/src/db/DatabaseTable.vala
+++ b/src/db/DatabaseTable.vala
@@ -180,7 +180,11 @@ public abstract class DatabaseTable {
         assert (res == Sqlite.OK);
     }
 
-    protected static void bind_text (Sqlite.Statement stmt, int column, string data) {
+    protected static void bind_text (Sqlite.Statement stmt, int column, string? data) {
+        if (data == null) {
+            bind_null (stmt, column);
+        }
+
         var res = stmt.bind_text (column, data);
         assert (res == Sqlite.OK);
     }

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -91,12 +91,12 @@ public class PhotoRow {
     public Orientation orientation;
     public Gee.HashMap<string, KeyValueMap>? transformations;
     public string md5;
-    public string thumbnail_md5;
-    public string exif_md5;
+    public string? thumbnail_md5;
+    public string? exif_md5;
     public time_t time_created;
     public uint64 flags;
-    public string title;
-    public string comment;
+    public string? title;
+    public string? comment;
     public string? backlinks;
     public time_t time_reimported;
     public BackingPhotoID editable_id;


### PR DESCRIPTION
Fixes #193 

The SQLite library was throwing assertions about trying to bind null pointers to strings in database queries.

Should be able to test this by running from the console and importing a new photo. The current master will probably spam the console with errors.