### PR TITLE
Prevent revealer stealing mouse events

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -63,9 +63,6 @@
     border-radius: 3px;
     box-shadow:
         0 0 0 1px alpha (#000, 0.2),
-        0 8px 10px 1px alpha (#000, 0.14),
-        0 3px 14px 2px alpha (#000, 0.12),
-        0 5px 5px -3px alpha (#000, 0.4),
         inset 1px 0 0 0 alpha (@bg_highlight_color, 0.2),
         inset -1px 0 0 0 alpha (@bg_highlight_color, 0.2),
         inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.3);

--- a/src/FullScreenWindow.vala
+++ b/src/FullScreenWindow.vala
@@ -76,6 +76,8 @@ public class FullscreenWindow : PageWindow {
         toolbar.insert (close_button, -1);
 
         revealer = new Gtk.Revealer ();
+        revealer.halign = Gtk.Align.CENTER;
+        revealer.valign = Gtk.Align.END;
         revealer.transition_type = Gtk.RevealerTransitionType.CROSSFADE;
         revealer.add (toolbar);
 


### PR DESCRIPTION
As explained in Slack. The revealer was filling the screen and stealing mouse events from the canvas underneath.

Can test by zooming into a photo in fullscreen mode and attempting to pan by dragging with and without this branch.

Juno possibly seems unaffected.