### PR TITLE
Remove deprecated set_has_resize_grip

### DIFF
--- a/src/Dialogs/TextEntryDialog.vala
+++ b/src/Dialogs/TextEntryDialog.vala
@@ -64,7 +64,6 @@ public class TextEntryDialog : Gtk.Dialog {
         }
 
         set_default_response (Gtk.ResponseType.OK);
-        set_has_resize_grip (false);
     }
 
     public string? execute () {

--- a/src/PageWindow.vala
+++ b/src/PageWindow.vala
@@ -37,8 +37,6 @@ public abstract class PageWindow : Gtk.Window {
         // the current page needs to know when modifier keys are pressed
         add_events (Gdk.EventMask.KEY_PRESS_MASK | Gdk.EventMask.KEY_RELEASE_MASK
                     | Gdk.EventMask.STRUCTURE_MASK);
-
-        set_has_resize_grip (false);
     }
 
     public Page? get_current_page () {


### PR DESCRIPTION
Deprecated since 3.14 and doesn't do anything anymore since the whole window is a resize edge