### PR TITLE
Fix initial blank collection in Juno

### DIFF
--- a/src/Checkerboard/CheckerboardItem.vala
+++ b/src/Checkerboard/CheckerboardItem.vala
@@ -43,7 +43,7 @@ public abstract class CheckerboardItem : ThumbnailView {
     private Gdk.Pixbuf pixbuf = null;
     private Gdk.Pixbuf display_pixbuf = null;
     private Gdk.Pixbuf brightened = null;
-    private Dimensions pixbuf_dim = Dimensions ();
+    protected Dimensions pixbuf_dim = Dimensions ();
     private int col = -1;
     private int row = -1;
 

--- a/src/MediaPage.vala
+++ b/src/MediaPage.vala
@@ -23,6 +23,8 @@ public class MediaSourceItem : CheckerboardItem {
     public MediaSourceItem (ThumbnailSource source, Dimensions initial_pixbuf_dim, string title,
                             string? comment, bool marked_up = false, Pango.Alignment alignment = Pango.Alignment.LEFT) {
         base (source, initial_pixbuf_dim, title, comment, marked_up, alignment);
+
+        pixbuf_dim = initial_pixbuf_dim;
     }
 }
 


### PR DESCRIPTION
Seems we've been hit by what looks like a bug in the Vala compiler again where properties on sub-classes aren't set properly.

I'm going to try and write an easily reproducible piece of sample code but this should fix the issue for now with no negative side effects.