### PR TITLE
Remove un-used interactive zoom code

### DIFF
--- a/src/Page.vala
+++ b/src/Page.vala
@@ -1952,21 +1952,6 @@ public abstract class SinglePhotoPage : Page {
         pixmap_ctx.paint ();
     }
 
-    protected void on_interactive_zoom (ZoomState interactive_zoom_state) {
-        assert (is_zoom_supported ());
-        Cairo.Context canvas_ctx = Gdk.cairo_create (canvas.get_window ());
-
-        canvas.get_style_context ().render_background (pixmap_ctx, 0, 0, pixmap_dim.width, pixmap_dim.height);
-
-        bool old_quality_setting = zoom_high_quality;
-        zoom_high_quality = false;
-        render_zoomed_to_pixmap (interactive_zoom_state);
-        zoom_high_quality = old_quality_setting;
-
-        canvas_ctx.set_source_surface (pixmap, 0, 0);
-        canvas_ctx.paint ();
-    }
-
     protected void on_interactive_pan (ZoomState interactive_zoom_state) {
         assert (is_zoom_supported ());
         Cairo.Context canvas_ctx = Gdk.cairo_create (canvas.get_window ());

--- a/src/PhotoPage.vala
+++ b/src/PhotoPage.vala
@@ -426,7 +426,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
     private PixbufCache cache = null;
     private PixbufCache master_cache = null;
     private DragAndDropHandler dnd_handler = null;
-    private bool enable_interactive_zoom_refresh = false;
     private Gdk.Point zoom_pan_start_point;
     private bool is_pan_in_progress = false;
     private double saved_slider_val = 0.0;
@@ -588,19 +587,13 @@ public abstract class EditingHostPage : SinglePhotoPage {
     private void on_zoom_slider_value_changed () {
         ZoomState new_zoom_state = ZoomState.rescale (get_zoom_state (), zoom_slider.slider_value);
 
-        if (enable_interactive_zoom_refresh) {
-            on_interactive_zoom (new_zoom_state);
-
-            if (new_zoom_state.is_default ())
-                set_zoom_state (new_zoom_state);
+        if (new_zoom_state.is_default ()) {
+            cancel_zoom ();
         } else {
-            if (new_zoom_state.is_default ()) {
-                cancel_zoom ();
-            } else {
-                set_zoom_state (new_zoom_state);
-            }
-            repaint ();
+            set_zoom_state (new_zoom_state);
         }
+
+        repaint ();
 
         update_cursor_for_zoom_context ();
     }


### PR DESCRIPTION
The boolean value `enable_interactive_zoom_refresh` was never set to true anywhere, so none of this code could be executed.