### PR TITLE
Revert valac workarounds

### DIFF
--- a/src/Checkerboard/CheckerboardItem.vala
+++ b/src/Checkerboard/CheckerboardItem.vala
@@ -43,7 +43,7 @@ public abstract class CheckerboardItem : ThumbnailView {
     private Gdk.Pixbuf pixbuf = null;
     private Gdk.Pixbuf display_pixbuf = null;
     private Gdk.Pixbuf brightened = null;
-    protected Dimensions pixbuf_dim = Dimensions ();
+    private Dimensions pixbuf_dim = Dimensions ();
     private int col = -1;
     private int row = -1;
 

--- a/src/MediaPage.vala
+++ b/src/MediaPage.vala
@@ -23,8 +23,6 @@ public class MediaSourceItem : CheckerboardItem {
     public MediaSourceItem (ThumbnailSource source, Dimensions initial_pixbuf_dim, string title,
                             string? comment, bool marked_up = false, Pango.Alignment alignment = Pango.Alignment.LEFT) {
         base (source, initial_pixbuf_dim, title, comment, marked_up, alignment);
-
-        pixbuf_dim = initial_pixbuf_dim;
     }
 }
 

--- a/src/PixbufCache.vala
+++ b/src/PixbufCache.vala
@@ -56,10 +56,6 @@ public class PixbufCache : Object {
         public BaselineFetchJob (PixbufCache owner, BackgroundJob.JobPriority priority, Photo photo,
                                  Scaling scaling, CompletionCallback callback) {
             base (owner, priority, photo, scaling, callback);
-
-            this.priority = priority;
-            this.photo = photo;
-            this.scaling = scaling;
         }
 
         public override void execute () {
@@ -75,10 +71,6 @@ public class PixbufCache : Object {
         public MasterFetchJob (PixbufCache owner, BackgroundJob.JobPriority priority, Photo photo,
                                Scaling scaling, CompletionCallback callback) {
             base (owner, priority, photo, scaling, callback);
-
-            this.priority = priority;
-            this.photo = photo;
-            this.scaling = scaling;
         }
 
         public override void execute () {
@@ -378,4 +370,3 @@ public class PixbufCache : Object {
         assert (removed);
     }
 }
-


### PR DESCRIPTION
These were added in #247 and #241 to workaround the Vala compiler bug:
https://bugzilla.gnome.org/show_bug.cgi?id=791785

This bug has now been fixed and a new version of Vala has been released, so no longer affects photos.