### PR TITLE
DirectWindow.vala: misc cleanup

### DIFF
--- a/src/direct/DirectWindow.vala
+++ b/src/direct/DirectWindow.vala
@@ -22,6 +22,7 @@ public class DirectWindow : AppWindow {
 
     public DirectWindow (File file) {
         direct_photo_page = new DirectPhotoPage (file);
+        direct_photo_page.expand = true;
         direct_photo_page.get_view ().items_altered.connect (on_photo_changed);
         direct_photo_page.get_view ().items_state_changed.connect (on_photo_changed);
 
@@ -31,23 +32,23 @@ public class DirectWindow : AppWindow {
 
         direct_photo_page.switched_to ();
 
-        // simple layout: menu on top, photo in center, toolbar along bottom (mimicking the
-        // PhotoPage in the library, but without the sidebar)
-        Gtk.Box layout = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        layout.pack_start (direct_photo_page, true, true, 0);
-        layout.pack_end (direct_photo_page.get_toolbar (), false, false, 0);
+        var layout = new Gtk.Grid ();
+        layout.orientation = Gtk.Orientation.VERTICAL;
+        layout.add (direct_photo_page);
+        layout.add (direct_photo_page.get_toolbar ());
 
         add (layout);
-        header.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
 
         var save_action = get_direct_page ().get_action ("Save");
         var save_btn = save_action.create_tool_item ();
         save_btn.sensitive = true;
-        header.pack_start (save_btn);
 
         var save_as_action = get_direct_page ().get_action ("SaveAs");
         var save_as_btn = save_as_action.create_tool_item ();
         save_as_btn.sensitive = true;
+
+        header.has_subtitle = false;
+        header.pack_start (save_btn);
         header.pack_start (save_as_btn);
     }
 


### PR DESCRIPTION
* Use Gtk.Grid instead of box
* Remove obvious comment
* Put all the headerbar stuff together in one spot