### PR TITLE
Ellipsize long titles

### DIFF
--- a/src/library/TopDisplay.vala
+++ b/src/library/TopDisplay.vala
@@ -54,6 +54,7 @@ public class TopDisplay : Gtk.Stack {
         hexpand = false;
 
         title_label = new Gtk.Label (_("Photos"));
+        title_label.set_ellipsize (Pango.EllipsizeMode.MIDDLE);
         title_label.get_style_context ().add_class (Gtk.STYLE_CLASS_TITLE);
 
         background_progress_label = new Gtk.Label (null);


### PR DESCRIPTION
shorten long titles so they don't expand the window
fixes #278 