### PR TITLE
AppWindow: Don't get undo/redo appearance from Gtk.Action

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -41,6 +41,9 @@ public abstract class AppWindow : PageWindow {
 
     private Gtk.ActionGroup common_action_group = new Gtk.ActionGroup ("AppWindowGlobalActionGroup");
 
+    private Gtk.Button redo_btn;
+    private Gtk.Button undo_btn;
+
     protected GLib.Settings window_settings;
 
     construct {
@@ -112,14 +115,16 @@ public abstract class AppWindow : PageWindow {
     }
 
     protected virtual void build_header_bar () {
-        var redo_action = get_common_action ("CommonRedo");
-        var redo_btn = redo_action.create_tool_item ();
-        redo_btn.sensitive = true;
-        header.pack_end (redo_btn);
+        redo_btn = new Gtk.Button ();
+        redo_btn.related_action = get_common_action ("CommonRedo");
+        redo_btn.image = new Gtk.Image.from_icon_name ("edit-redo", Gtk.IconSize.LARGE_TOOLBAR);
 
-        var undo_action = get_common_action ("CommonUndo");
-        var undo_btn = undo_action.create_tool_item ();
-        undo_btn.sensitive = true;
+        undo_btn = new Gtk.Button ();
+        undo_btn.related_action = get_common_action ("CommonUndo");
+        undo_btn.image = new Gtk.Image.from_icon_name ("edit-undo", Gtk.IconSize.LARGE_TOOLBAR);
+
+
+        header.pack_end (redo_btn);
         header.pack_end (undo_btn);
     }
 
@@ -127,8 +132,8 @@ public abstract class AppWindow : PageWindow {
     private Gtk.ActionEntry[] create_common_actions () {
         Gtk.ActionEntry quit = { "CommonQuit", null, _("_Quit"), "<Ctrl>Q", _("_Quit"), on_quit };
         Gtk.ActionEntry fullscreen = { "CommonFullscreen", null, _("Fulls_creen"), "F11", _("Fulls_creen"), on_fullscreen };
-        Gtk.ActionEntry undo = { "CommonUndo", "edit-undo", Resources.UNDO_MENU, "<Ctrl>Z", Resources.UNDO_MENU, on_undo };
-        Gtk.ActionEntry redo = { "CommonRedo", "edit-redo", Resources.REDO_MENU, "<Ctrl><Shift>Z", Resources.REDO_MENU, on_redo };
+        Gtk.ActionEntry undo = { "CommonUndo", null, null, "<Ctrl>Z", null, on_undo };
+        Gtk.ActionEntry redo = { "CommonRedo", null, null, "<Ctrl><Shift>Z", null, on_redo };
         Gtk.ActionEntry jump_to_file = { "CommonJumpToFile", null, Resources.JUMP_TO_FILE_MENU, "<Ctrl><Shift>M", Resources.JUMP_TO_FILE_MENU, on_jump_to_file };
         Gtk.ActionEntry select_all = { "CommonSelectAll", null, Resources.SELECT_ALL_MENU, "<Ctrl>A", Resources.SELECT_ALL_MENU, on_select_all };
         Gtk.ActionEntry select_none = { "CommonSelectNone", null, null, "<Ctrl><Shift>A", TRANSLATABLE, on_select_none };
@@ -486,31 +491,27 @@ public abstract class AppWindow : PageWindow {
         decorate_redo_action ();
     }
 
-    private void decorate_command_manager_action (string name, string prefix,
-            string default_explanation, CommandDescription? desc) {
+    private void decorate_command_manager_action (string name, Gtk.Button button, string default_explanation, CommandDescription? desc) {
         Gtk.Action? action = get_common_action (name);
-        if (action == null)
+        if (action == null) {
             return;
+        }
 
         if (desc != null) {
-            action.label = "%s %s".printf (prefix, desc.get_name ());
-            action.tooltip = action.label;
+            button.tooltip_text = "%s %s".printf (default_explanation, desc.get_name ());
             action.sensitive = true;
         } else {
-            action.label = prefix;
-            action.tooltip = default_explanation;
+            button.tooltip_text = default_explanation;
             action.sensitive = false;
         }
     }
 
     public void decorate_undo_action () {
-        decorate_command_manager_action ("CommonUndo", Resources.UNDO_LABEL, "",
-                                         get_command_manager ().get_undo_description ());
+        decorate_command_manager_action ("CommonUndo", undo_btn, _("Undo"), get_command_manager ().get_undo_description ());
     }
 
     public void decorate_redo_action () {
-        decorate_command_manager_action ("CommonRedo", Resources.REDO_LABEL, "",
-                                         get_command_manager ().get_redo_description ());
+        decorate_command_manager_action ("CommonRedo", redo_btn, _("Redo"), get_command_manager ().get_redo_description ());
     }
 
     private void on_undo () {

--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -173,12 +173,6 @@ public const string SET_BACKGROUND_MENU = _("Set as _Desktop Background");
 public const string SET_BACKGROUND_TOOLTIP = _("Set selected image to be the new desktop background");
 public const string SET_BACKGROUND_SLIDESHOW_MENU = _("Set as _Desktop Slideshow...");
 
-public const string UNDO_MENU = _("_Undo");
-public const string UNDO_LABEL = _("Undo");
-
-public const string REDO_MENU = _("_Redo");
-public const string REDO_LABEL = _("Redo");
-
 public const string RENAME_EVENT_MENU = _("Re_name Event...");
 public const string RENAME_EVENT_LABEL = _("Rename Event");
 


### PR DESCRIPTION
Gets us a little closer to a world where we can use GLib.Action by not relying on Gtk.Action for setting button labels, icons, tooltips, etc

We still rely on sensitivity from the action because:
1. This is still supported in GLib.Action
2. This also controls the sensitivity of accelerators