### PR TITLE
Remove abstracted set_default_title method

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -60,7 +60,7 @@ public abstract class AppWindow : PageWindow {
         header.set_show_close_button (true);
         this.set_titlebar (header);
 
-        set_default_title ();
+        title = _(Resources.APP_TITLE);
 
         var css_provider = new Gtk.CssProvider ();
         css_provider.load_from_resource ("io/elementary/photos/application.css");
@@ -108,10 +108,6 @@ public abstract class AppWindow : PageWindow {
         add_accel_group (ui.get_accel_group ());
 
         build_header_bar ();
-    }
-
-    protected virtual void set_default_title () {
-        title = _ (Resources.APP_TITLE);
     }
 
     protected virtual void build_header_bar () {

--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -18,7 +18,8 @@
 */
 
 namespace Resources {
-public const string APP_TITLE = _("Photos");
+// TRANSLATORS: This is the application name, not a category or mimetype name
+public const string APP_TITLE = N_("Photos");
 public const string APP_TITLE_VIEWER = _("Photos Viewer");
 public const string APP_LIBRARY_ROLE = _("Photo Manager");
 public const string APP_DIRECT_ROLE = _("Photo Viewer");

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -1334,7 +1334,7 @@ public class LibraryWindow : AppWindow {
         } else {
             // having no page is unlikely, but set the good old default title
             // just in case
-            set_default_title ();
+            title = _(Resources.APP_TITLE);
         }
     }
 }


### PR DESCRIPTION
Having the string in a constant is plenty abstracted for maintenance purposes. We don't need to abstract an obvious one-line method