### PR TITLE
Replace deprecated gdk.screen

### DIFF
--- a/src/Dimensions.vala
+++ b/src/Dimensions.vala
@@ -332,10 +332,13 @@ public struct Scaling {
     }
 
     private static Dimensions get_screen_dimensions (Gtk.Window window) {
-        Gdk.Screen screen = window.get_screen ();
+        var display = window.get_window ().get_display ();
+        var monitor = display.get_monitor_at_window (window.get_window ());
+        var geometry = monitor.get_geometry ();
+
         int scale_factor = window.scale_factor;
 
-        return Dimensions (screen.get_width () * scale_factor, screen.get_height () * scale_factor);
+        return Dimensions (geometry.width * scale_factor, geometry.height * scale_factor);
     }
 
     private int scale_to_pixels () {

--- a/src/Dimensions.vala
+++ b/src/Dimensions.vala
@@ -331,7 +331,7 @@ public struct Scaling {
         return Scaling (constraint, scale, Dimensions (), scale_up);
     }
 
-    private static Dimensions get_screen_dimensions (Gtk.Window window) {
+    public static Dimensions get_screen_dimensions (Gtk.Window window) {
         var display = window.get_window ().get_display ();
         var monitor = display.get_monitor_at_window (window.get_window ());
         var geometry = monitor.get_geometry ();

--- a/src/EditingHostPage.vala
+++ b/src/EditingHostPage.vala
@@ -1870,10 +1870,9 @@ public abstract class EditingHostPage : SinglePhotoPage {
                 Gtk.Allocation toolbar_alloc;
                 get_toolbar ().get_allocation (out toolbar_alloc);
 
-                Gdk.Screen screen = get_container ().get_screen ();
-                x = screen.get_width ();
-                y = screen.get_height () - toolbar_alloc.height -
-                    tool_alloc.height - TOOL_WINDOW_SEPARATOR;
+                var dimensions = Scaling.get_screen_dimensions (get_container ());
+                x = dimensions.width;
+                y = dimensions.height - toolbar_alloc.height - tool_alloc.height - TOOL_WINDOW_SEPARATOR;
 
                 // put larger adjust tool off to the side
                 if (current_tool is EditingTools.AdjustTool) {
@@ -1885,9 +1884,9 @@ public abstract class EditingHostPage : SinglePhotoPage {
         }
 
         // however, clamp the window so it's never off-screen initially
-        Gdk.Screen screen = get_container ().get_screen ();
-        x = x.clamp (0, screen.get_width () - tool_alloc.width);
-        y = y.clamp (0, screen.get_height () - tool_alloc.height);
+        var dimensions = Scaling.get_screen_dimensions (get_container ());
+        x = x.clamp (0, dimensions.width - tool_alloc.width);
+        y = y.clamp (0, dimensions.height - tool_alloc.height);
 
         tool_window.move (x, y);
         tool_window.show ();

--- a/src/FullScreenWindow.vala
+++ b/src/FullScreenWindow.vala
@@ -111,12 +111,8 @@ public class FullscreenWindow : PageWindow {
     }
 
     private Gdk.Rectangle get_monitor_geometry () {
-        Gdk.Rectangle monitor;
-
-        get_screen ().get_monitor_geometry (
-            get_screen ().get_monitor_at_window (AppWindow.get_instance ().get_window ()), out monitor);
-
-        return monitor;
+        var monitor = get_display ().get_monitor_at_window (AppWindow.get_instance ().get_window ());
+        return monitor.get_geometry ();
     }
 
     public override bool configure_event (Gdk.EventConfigure event) {

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -357,7 +357,7 @@ public class EditingTools.CropTool : EditingTool {
             result = ((float) canvas.get_scaled_pixbuf_position ().width) /
                      ((float) canvas.get_scaled_pixbuf_position ().height);
         } else if (result == SCREEN_ASPECT_RATIO) {
-            var dimensions = Scaling.get_screen_dimensions(AppWindow.get_instance());
+            var dimensions = Scaling.get_screen_dimensions (AppWindow.get_instance ());
             result = ((float) dimensions.width) / ((float) dimensions.height);
         } else if (result == CUSTOM_ASPECT_RATIO) {
             result = custom_aspect_ratio;

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -247,9 +247,9 @@ public class EditingTools.CropTool : EditingTool {
             result.basis_width = canvas.get_scaled_pixbuf_position ().width;
             result.basis_height = canvas.get_scaled_pixbuf_position ().height;
         } else if (result.aspect_ratio == SCREEN_ASPECT_RATIO) {
-            Gdk.Screen screen = Gdk.Screen.get_default ();
-            result.basis_width = screen.get_width ();
-            result.basis_height = screen.get_height ();
+            var dimensions = Scaling.get_screen_dimensions (AppWindow.get_instance ());
+            result.basis_width = dimensions.width;
+            result.basis_height = dimensions.height;
         }
 
         return result;
@@ -357,8 +357,8 @@ public class EditingTools.CropTool : EditingTool {
             result = ((float) canvas.get_scaled_pixbuf_position ().width) /
                      ((float) canvas.get_scaled_pixbuf_position ().height);
         } else if (result == SCREEN_ASPECT_RATIO) {
-            Gdk.Screen screen = Gdk.Screen.get_default ();
-            result = ((float) screen.get_width ()) / ((float) screen.get_height ());
+            var dimensions = Scaling.get_screen_dimensions(AppWindow.get_instance());
+            result = ((float) dimensions.width) / ((float) dimensions.height);
         } else if (result == CUSTOM_ASPECT_RATIO) {
             result = custom_aspect_ratio;
         }


### PR DESCRIPTION
Based on:
* https://gitlab.gnome.org/GNOME/shotwell/commit/1b56db4b2bd9ee9ff35d2a91fcef7736f3431031
* https://gitlab.gnome.org/GNOME/shotwell/commit/b8309dd361b2fbfb284a30c31ffa87ad24d5f5f8

This branch can be rebase merged if that's desired