### PR TITLE
SliderAssembly.vala: Replace deprecated gtk_timeout_foo

### DIFF
--- a/src/Widgets/SliderAssembly.vala
+++ b/src/Widgets/SliderAssembly.vala
@@ -144,8 +144,8 @@ public class SliderAssembly : Gtk.Grid {
         clear_timeouts ();
 
         active_box = (Gtk.EventBox)sender;
-        initial_wait_id = Timeout.add (settings.gtk_timeout_initial, () => {
-            click_id = Timeout.add (settings.gtk_timeout_repeat, step_callback);
+        initial_wait_id = Timeout.add (200, () => {
+            click_id = Timeout.add (20, step_callback);
             initial_wait_id = 0;
             return false;
         });


### PR DESCRIPTION
Replace these deprecated properties with their default values as defined here: https://developer.gnome.org/gtk2/stable/GtkSettings.html#GtkSettings--gtk-timeout-initial