### PR TITLE
Page.vala: Revert gtk.menu.popup change

### DIFF
--- a/src/Page.vala
+++ b/src/Page.vala
@@ -1025,7 +1025,11 @@ public abstract class Page : Gtk.ScrolledWindow {
         if (context_menu == null || !on_context_invoked ())
             return false;
 
-        context_menu.popup_at_pointer (event);
+        if (event == null) {
+            context_menu.popup (null, null, null, 0, Gtk.get_current_event_time ());
+        } else {
+            context_menu.popup (null, null, null, event.button, event.time);
+        }
 
         return true;
     }


### PR DESCRIPTION
For some reason I'm getting menus popping up at `0,0` on the display. Revert real quick until we can figure out a proper fix