### PR TITLE
AppWindow: use built-in actiongroup

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -52,9 +52,7 @@ public abstract class AppWindow : PageWindow {
     };
 
     construct {
-        var actions = new SimpleActionGroup ();
-        actions.add_action_entries (action_entries, this);
-        insert_action_group ("win", actions);
+        add_action_entries (action_entries, this);
 
         Application.get_instance ().set_accels_for_action (ACTION_PREFIX + ACTION_QUIT, {"<Ctrl>Q"});
 

--- a/src/PageWindow.vala
+++ b/src/PageWindow.vala
@@ -24,7 +24,7 @@
 // subclass.  A subclass should set current_page to the user-visible Page for it to receive
 // various notifications.  It is the responsibility of the subclass to notify Pages when they're
 // switched to and from, and other aspects of the Page interface.
-public abstract class PageWindow : Gtk.Window {
+public abstract class PageWindow : Gtk.ApplicationWindow {
     protected Gtk.UIManager ui = new Gtk.UIManager ();
 
     private Page current_page = null;


### PR DESCRIPTION
This is going to be the basis for a lot of future GLib.Action branches. It turns out Gtk.ApplicationWindow has a built in actiongroup, so this makes it a lot easier for us to look up actions from other classes. Pretty neat