### PR TITLE
TextEntryDialog: Rewrite without UI files

### DIFF
--- a/data/shotwell.ui
+++ b/data/shotwell.ui
@@ -362,46 +362,6 @@
       </packing>
     </child>
   </object>
-  <object class="GtkBox" id="dialog-vbox2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="orientation">vertical</property>
-    <child>
-      <object class="GtkLabel" id="label">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="xalign">0</property>
-        <property name="xpad">4</property>
-        <property name="label" translatable="yes">label</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="padding">4</property>
-        <property name="position">0</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkEntry" id="entry">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="margin_left">7</property>
-        <property name="margin_right">7</property>
-        <property name="margin_bottom">2</property>
-        <property name="invisible_char">●</property>
-        <property name="activates_default">True</property>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="padding">1</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <placeholder/>
-    </child>
-  </object>
   <object class="GtkBox" id="dialog-vbox4">
     <property name="visible">True</property>
     <property name="can_focus">False</property>

--- a/src/Dialogs/Dialogs.vala
+++ b/src/Dialogs/Dialogs.vala
@@ -615,11 +615,7 @@ public abstract class TextEntryDialogMediator {
 
     public TextEntryDialogMediator (string title, string label, string? initial_text = null,
                                     Gee.Collection<string>? completion_list = null, string? completion_delimiter = null) {
-        Gtk.Builder builder = AppWindow.create_builder ();
-        dialog = new TextEntryDialog ();
-        dialog.get_content_area ().add ((Gtk.Box) builder.get_object ("dialog-vbox2"));
-        dialog.set_builder (builder);
-        dialog.setup (on_modify_validate, title, label, initial_text, completion_list, completion_delimiter);
+        dialog = new TextEntryDialog (on_modify_validate, title, label, initial_text, completion_list, completion_delimiter);
     }
 
     protected virtual bool on_modify_validate (string text) {

--- a/src/Dialogs/TextEntryDialog.vala
+++ b/src/Dialogs/TextEntryDialog.vala
@@ -29,8 +29,14 @@ public class TextEntryDialog : Gtk.Dialog {
     private unowned OnModifyValidateType on_modify_validate;
     private Gtk.Entry entry;
 
-    public TextEntryDialog (OnModifyValidateType? modify_validate, string title, string label,
-string? initial_text, Gee.Collection<string>? completion_list, string? completion_delimiter) {
+    public TextEntryDialog (
+        OnModifyValidateType? modify_validate,
+        string title,
+        string label,
+        string? initial_text,
+        Gee.Collection<string>? completion_list,
+        string? completion_delimiter
+    ) {
         Object (
             completion_delimiter: completion_delimiter,
             completion_list: completion_list,
@@ -49,7 +55,7 @@ string? initial_text, Gee.Collection<string>? completion_list, string? completio
 
         entry = new Gtk.Entry ();
         entry.hexpand = true;
-        entry.text = initial_text != null ? initial_text : "";
+        entry.text = initial_text ?? "";
         entry.grab_focus ();
 
         if (completion_list != null) { // Textfield with autocompletion

--- a/src/Dialogs/TextEntryDialog.vala
+++ b/src/Dialogs/TextEntryDialog.vala
@@ -1,6 +1,6 @@
 /*
 * Copyright (c) 2009-2013 Yorba Foundation
-*               2017 elementary  LLC. (https://github.com/elementary/photos)
+*               2017-2018 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
@@ -19,51 +19,62 @@
 */
 
 public class TextEntryDialog : Gtk.Dialog {
+    public string initial_text { get; construct; }
+    public string label { get; construct; }
+    public Gee.Collection<string>? completion_list { get; construct; }
+    public string? completion_delimiter { get; construct; }
+
     public delegate bool OnModifyValidateType (string text);
 
     private unowned OnModifyValidateType on_modify_validate;
     private Gtk.Entry entry;
-    private Gtk.Builder builder;
-    private Gtk.Button button1;
-    private Gtk.Button button2;
-    private Gtk.ButtonBox action_area_box;
 
-    public void set_builder (Gtk.Builder builder) {
-        this.builder = builder;
+    public TextEntryDialog (OnModifyValidateType? modify_validate, string title, string label,
+string? initial_text, Gee.Collection<string>? completion_list, string? completion_delimiter) {
+        Object (
+            completion_delimiter: completion_delimiter,
+            completion_list: completion_list,
+            initial_text: initial_text,
+            label: label,
+            title: title
+        );
+
+        on_modify_validate = modify_validate;
     }
 
-    public void setup (OnModifyValidateType? modify_validate, string title, string label,
-                       string? initial_text, Gee.Collection<string>? completion_list, string? completion_delimiter) {
-        set_title (title);
-        set_resizable (true);
-        set_deletable (false);
-        set_default_size (350, 104);
-        set_parent_window (AppWindow.get_instance ().get_parent_window ());
-        set_transient_for (AppWindow.get_instance ());
-        on_modify_validate = modify_validate;
+    construct {
+        var name_label = new Gtk.Label (label);
+        name_label.halign = Gtk.Align.START;
+        name_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
-        Gtk.Label name_label = builder.get_object ("label") as Gtk.Label;
-        name_label.set_text (label);
-
-        entry = builder.get_object ("entry") as Gtk.Entry;
-        entry.set_text (initial_text != null ? initial_text : "");
+        entry = new Gtk.Entry ();
+        entry.hexpand = true;
+        entry.text = initial_text != null ? initial_text : "";
         entry.grab_focus ();
-        entry.changed.connect (on_entry_changed);
-
-        action_area_box = (Gtk.ButtonBox) get_action_area ();
-        action_area_box.set_layout (Gtk.ButtonBoxStyle.END);
-
-        button1 = (Gtk.Button) add_button (_ ("_Cancel"), Gtk.ResponseType.CANCEL);
-        button2 = (Gtk.Button) add_button (_ ("_Save"), Gtk.ResponseType.OK);
-        set_default_response (Gtk.ResponseType.OK);
 
         if (completion_list != null) { // Textfield with autocompletion
-            EntryMultiCompletion completion = new EntryMultiCompletion (completion_list,
-                    completion_delimiter);
-            entry.set_completion (completion);
+            entry.completion = new EntryMultiCompletion (completion_list, completion_delimiter);
         }
 
+        var grid = new Gtk.Grid ();
+        grid.margin_start = grid.margin_end = 6;
+        grid.margin_bottom = 18;
+        grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.add (name_label);
+        grid.add (entry);
+
+        get_content_area ().add (grid);
+
+        add_button (_("_Cancel"), Gtk.ResponseType.CANCEL);
+        add_button (_("_Save"), Gtk.ResponseType.OK);
+
+        deletable = false;
+        resizable = false;
+        transient_for = AppWindow.get_instance ();
+        set_default_size (350, 104);
         set_default_response (Gtk.ResponseType.OK);
+
+        entry.changed.connect (on_entry_changed);
     }
 
     public string? execute () {
@@ -83,7 +94,7 @@ public class TextEntryDialog : Gtk.Dialog {
         return text;
     }
 
-    public void on_entry_changed () {
+    private void on_entry_changed () {
         set_response_sensitive (Gtk.ResponseType.OK, on_modify_validate (entry.get_text ()));
     }
 }


### PR DESCRIPTION
Rewrites the dialog with GObject-style construction (almost) and no UI files or Gtk.Builder or anything.

Solves a few deprecation warnings