### PR TITLE
EditingTools: rewrite EditingToolWindow as a Gtk.Dialog

### DIFF
--- a/src/editing_tools/AdjustTool.vala
+++ b/src/editing_tools/AdjustTool.vala
@@ -122,7 +122,7 @@ public class EditingTools.AdjustTool : EditingTool {
             var grid = new Gtk.Grid ();
             grid.column_spacing = 12;
             grid.row_spacing = 12;
-            grid.margin = 12;
+            grid.margin_start = grid.margin_end = 12;
             grid.attach (histogram_manipulator, 0, 0, 2, 1);
             grid.attach (exposure_label, 0, 1, 1, 1);
             grid.attach (exposure_slider, 1, 1, 1, 1);
@@ -138,7 +138,7 @@ public class EditingTools.AdjustTool : EditingTool {
             grid.attach (highlights_slider, 1, 6, 1, 1);
             grid.attach (button_box, 0, 7, 2, 1);
 
-            add (grid);
+            get_content_area ().add (grid);
         }
     }
 

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -125,12 +125,12 @@ public class EditingTools.CropTool : EditingTool {
             response_layout.add (ok_button);
 
             layout = new Gtk.Box (Gtk.Orientation.HORIZONTAL, CONTROL_SPACING);
-            layout.margin = 12;
+            layout.margin_start = layout.margin_end = 12;
             layout.add (constraint_combo);
             layout.add (pivot_reticle_button);
             layout.add (response_layout);
 
-            add (layout);
+            get_content_area ().add (layout);
         }
 
         private static bool constraint_combo_separator_func (Gtk.TreeModel model, Gtk.TreeIter iter) {

--- a/src/editing_tools/EditingTools.vala
+++ b/src/editing_tools/EditingTools.vala
@@ -28,24 +28,20 @@
 
 namespace EditingTools {
 
-public abstract class EditingToolWindow : Gtk.Window {
-
-    private Gtk.Frame outer_frame = new Gtk.Frame (null);
+public abstract class EditingToolWindow : Gtk.Dialog {
     private bool user_moved = false;
 
     public EditingToolWindow (Gtk.Window container) {
-        // needed so that windows will appear properly in fullscreen mode
-        type_hint = Gdk.WindowTypeHint.UTILITY;
+        Object (transient_for: container);
+    }
 
-        set_decorated (false);
-        set_transient_for (container);
-
-        base.add (outer_frame);
+    construct {
+        accept_focus = true;
+        can_focus = true;
+        deletable = false;
+        focus_on_map = true;
 
         add_events (Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.KEY_PRESS_MASK);
-        focus_on_map = true;
-        set_accept_focus (true);
-        set_can_focus (true);
 
         // Needed to prevent the (spurious) 'This event was synthesised outside of GDK'
         // warnings after a keypress.
@@ -54,10 +50,6 @@ public abstract class EditingToolWindow : Gtk.Window {
 
     ~EditingToolWindow () {
         Log.set_handler ("Gdk", LogLevelFlags.LEVEL_WARNING, Log.default_handler);
-    }
-
-    public override void add (Gtk.Widget widget) {
-        outer_frame.add (widget);
     }
 
     public bool has_user_moved () {

--- a/src/editing_tools/EditingTools.vala
+++ b/src/editing_tools/EditingTools.vala
@@ -40,6 +40,7 @@ public abstract class EditingToolWindow : Gtk.Dialog {
         can_focus = true;
         deletable = false;
         focus_on_map = true;
+        resizable = false;
 
         add_events (Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.KEY_PRESS_MASK);
 

--- a/src/editing_tools/RedEyeTool.vala
+++ b/src/editing_tools/RedEyeTool.vala
@@ -80,13 +80,13 @@ public class EditingTools.RedeyeTool : EditingTool {
             apply_button.set_tooltip_text (_ ("Remove any red-eye effects in the selected region"));
 
             Gtk.Box layout = new Gtk.Box (Gtk.Orientation.HORIZONTAL, CONTROL_SPACING);
-            layout.margin = 12;
+            layout.margin_start = layout.margin_end = 12;
             layout.add (slider_label);
             layout.add (slider);
             layout.add (close_button);
             layout.add (apply_button);
 
-            add (layout);
+            get_content_area ().add (layout);
         }
     }
 

--- a/src/editing_tools/StraightenTool.vala
+++ b/src/editing_tools/StraightenTool.vala
@@ -141,13 +141,13 @@ public class StraightenTool : EditingTool {
             button_layout.pack_start (ok_button, true, true, 0);
 
             Gtk.Box main_layout = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            main_layout.margin = 12;
+            main_layout.margin_start = main_layout.margin_end = 12;
             main_layout.pack_start (description_label, true, true, 0);
             main_layout.pack_start (slider_layout, true, true, 0);
             main_layout.pack_start (angle_label, true, true, 0);
             main_layout.pack_start (button_layout, true, true, 0);
 
-            add (main_layout);
+            get_content_area ().add (main_layout);
 
             reset_button.clicked.connect (on_reset_clicked);
 


### PR DESCRIPTION
With GObject style and everything

## BEFORE
![screenshot from 2018-08-26 10 58 29 2x](https://user-images.githubusercontent.com/7277719/44631314-ff2c3380-a91e-11e8-8d04-cf0b87e77146.png)

## AFTER
![screenshot from 2018-08-26 10 55 08 2x](https://user-images.githubusercontent.com/7277719/44631316-03585100-a91f-11e8-8631-54bb4b6f8874.png)
