### PR TITLE
AppWindow.vala: Use Granite.MessageDialog for error dialog

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -161,17 +161,14 @@ public abstract class AppWindow : PageWindow {
         error_message_with_title (_ (Resources.APP_TITLE), message, parent);
     }
 
-    public static void error_message_with_title (string title, string message, Gtk.Window? parent = null, bool should_escape = true) {
-        // Per the Gnome HIG (http://library.gnome.org/devel/hig-book/2.32/windows-alert.html.en),
-        // alert-style dialogs mustn't have titles; we use the title as the primary text, and the
-        // existing message as the secondary text.
-        Gtk.MessageDialog dialog = new Gtk.MessageDialog.with_markup ((parent != null) ? parent : get_instance (),
-                Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, "%s", build_alert_body_text (title, message, should_escape));
-
-        // Occasionally, with_markup doesn't actually do anything, but set_markup always works.
-        dialog.set_markup (build_alert_body_text (title, message, should_escape));
-
-        dialog.use_markup = true;
+    public static void error_message_with_title (string title, string message, Gtk.Window? parent = null) {
+        var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+            title,
+            message,
+            "dialog-error",
+            Gtk.ButtonsType.CLOSE
+        );
+        dialog.transient_for = (parent != null) ? parent : get_instance ();
         dialog.run ();
         dialog.destroy ();
     }

--- a/src/publishing/PublishingUI.vala
+++ b/src/publishing/PublishingUI.vala
@@ -402,9 +402,11 @@ public class PublishingDialog : Gtk.Dialog {
         if (avail_services.length == 0) {
             // There are no enabled publishing services that accept this media type,
             // warn the user.
-            AppWindow.error_message_with_title (_ ("Unable to publish"),
-                                                _ ("Photos cannot publish the selected items because you do not have a compatible publishing plugin enabled. To correct this, choose <b>Edit %s Preferences</b> and enable one or more of the publishing plugins on the <b>Plugins</b> tab.").printf ("▸"),
-                                                null, false);
+            AppWindow.error_message_with_title (
+                _("Unable to publish"),
+                _("Photos cannot publish the selected items because you do not have a compatible publishing plugin enabled. To correct this, choose <b>Edit %s Preferences</b> and enable one or more of the publishing plugins on the <b>Plugins</b> tab.").printf ("▸"),
+                null
+            );
 
             return;
         }


### PR DESCRIPTION
Uses Granite.MessageDialog instead of Gtk.MessageDialog

## BEFORE
![screenshot from 2018-08-30 14 47 51 2x](https://user-images.githubusercontent.com/7277719/44881237-c3b5a000-ac63-11e8-8443-9163e01b543b.png)

## AFTER
![screenshot from 2018-08-30 14 45 55 2x](https://user-images.githubusercontent.com/7277719/44881239-c87a5400-ac63-11e8-9e6b-10fe95ef81c5.png)
