### PR TITLE
Move negate_affirm_question to Dialogs and use Granite.MessageDialog

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -176,22 +176,6 @@ public abstract class AppWindow : PageWindow {
         dialog.destroy ();
     }
 
-    public static bool negate_affirm_question (string message, string negative, string affirmative,
-            string? title = null, Gtk.Window? parent = null) {
-        Gtk.MessageDialog dialog = new Gtk.MessageDialog ((parent != null) ? parent : get_instance (),
-                Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE, "%s", build_alert_body_text (title, message));
-
-        dialog.set_markup (build_alert_body_text (title, message));
-        dialog.add_buttons (negative, Gtk.ResponseType.NO, affirmative, Gtk.ResponseType.YES);
-        dialog.set_urgency_hint (true);
-
-        bool response = (dialog.run () == Gtk.ResponseType.YES);
-
-        dialog.destroy ();
-
-        return response;
-    }
-
     public static Gtk.ResponseType affirm_cancel_negate_question (string message,
             string affirmative, string negative,
             string? title = null, Gtk.Window? parent = null) {

--- a/src/Dialogs/Dialogs.vala
+++ b/src/Dialogs/Dialogs.vala
@@ -21,7 +21,7 @@
 // place: http://trac.yorba.org/ticket/3452
 namespace Dialogs {
 
-public static bool negate_affirm_question (string message, string title) {
+private static bool negate_affirm_question (string message, string title) {
     var dialog = new Granite.MessageDialog.with_image_from_icon_name (
         title,
         message,

--- a/src/Dialogs/Dialogs.vala
+++ b/src/Dialogs/Dialogs.vala
@@ -21,6 +21,27 @@
 // place: http://trac.yorba.org/ticket/3452
 namespace Dialogs {
 
+public static bool negate_affirm_question (string message, string title) {
+    var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+        title,
+        message,
+        "dialog-question",
+        Gtk.ButtonsType.NONE
+    );
+    dialog.transient_for = AppWindow.get_instance ();
+    dialog.set_urgency_hint (true);
+    dialog.add_button (_("_Cancel"), Gtk.ResponseType.NO);
+
+    var delete_button = (Gtk.Button) dialog.add_button (_("_Delete"), Gtk.ResponseType.YES);
+    delete_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+
+    bool response = (dialog.run () == Gtk.ResponseType.YES);
+
+    dialog.destroy ();
+
+    return response;
+}
+
 public bool confirm_delete_tag (Tag tag) {
     int count = tag.get_sources_count ();
     if (count == 0)
@@ -30,16 +51,14 @@ public bool confirm_delete_tag (Tag tag) {
                      "This will remove the tag \"%s\" from %d photos.  Continue?",
                      count).printf (tag.get_user_visible_name (), count);
 
-    return AppWindow.negate_affirm_question (msg, _ ("_Cancel"), _ ("_Delete"),
-            Resources.DELETE_TAG_TITLE);
+    return negate_affirm_question (msg, Resources.DELETE_TAG_TITLE);
 }
 
 public bool confirm_delete_saved_search (SavedSearch search) {
     string msg = _ ("This will remove the smart album \"%s\".  Continue?")
                  .printf (search.get_name ());
 
-    return AppWindow.negate_affirm_question (msg, _ ("_Cancel"), _ ("_Delete"),
-            Resources.DELETE_SAVED_SEARCH_DIALOG_TITLE);
+    return negate_affirm_question (msg, Resources.DELETE_SAVED_SEARCH_DIALOG_TITLE);
 }
 
 public bool confirm_warn_developer_changed (int number) {


### PR DESCRIPTION
* This is only used in Dialogs.vala so move from AppWindow.vala
* Use Granite.MessageDialog
* Use destructive action class
* Remove arguments that are always set to the same thing

## BEFORE
![screenshot from 2018-08-30 15 05 18 2x](https://user-images.githubusercontent.com/7277719/44881916-214aec00-ac66-11e8-87b9-2abf98529226.png)

## AFTER
![screenshot from 2018-08-30 15 01 37 2x](https://user-images.githubusercontent.com/7277719/44881859-024c5a00-ac66-11e8-9d16-146c432f02cb.png)
