### PR TITLE
Clean up Cancel Affirm Question dialog

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -168,24 +168,21 @@ public abstract class AppWindow : PageWindow {
             "dialog-error",
             Gtk.ButtonsType.CLOSE
         );
-        dialog.transient_for = (parent != null) ? parent : get_instance ();
+        dialog.transient_for = parent ?? get_instance ();
         dialog.run ();
         dialog.destroy ();
     }
 
-    public static Gtk.ResponseType cancel_affirm_question (string message, string affirmative,
-            string? title = null, Gtk.Window? parent = null) {
-        Gtk.MessageDialog dialog = new Gtk.MessageDialog.with_markup ((parent != null) ? parent : get_instance (),
-                Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE, "%s", message);
-        // Occasionally, with_markup doesn't actually enable markup...? Force the issue.
-        dialog.set_markup (message);
-        dialog.use_markup = true;
-        dialog.title = (title != null) ? title : _ (Resources.APP_TITLE);
-        dialog.add_buttons (_("_Cancel"), Gtk.ResponseType.CANCEL,
-                            affirmative, Gtk.ResponseType.YES);
-
+    public static Gtk.ResponseType cancel_affirm_question (string message, string affirmative, string? title = null) {
+        var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+            title ?? _(Resources.APP_TITLE),
+            message,
+            "dialog-question",
+            Gtk.ButtonsType.CANCEL
+        );
+        dialog.transient_for = get_instance ();
+        dialog.add_button (affirmative, Gtk.ResponseType.YES);
         int response = dialog.run ();
-
         dialog.destroy ();
 
         return (Gtk.ResponseType) response;

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -727,11 +727,14 @@ public class LibraryWindow : AppWindow {
 
     private void dispatch_import_jobs (GLib.SList<string> uris, string job_name, bool copy_to_library) {
         if (AppDirs.get_import_dir ().get_path () == Environment.get_home_dir () && notify_library_is_home_dir) {
-            Gtk.ResponseType response = AppWindow.cancel_affirm_question (
-                                            _ ("Photos is configured to import photos to your home directory.\n" +
-                                               "We recommend changing this in <span weight=\"bold\">Edit %s Preferences</span>.\n" +
-                                               "Do you want to continue importing photos?").printf ("▸"),
-                                            _ ("_Import"), _ ("Library Location"), AppWindow.get_instance ());
+            var response = AppWindow.cancel_affirm_question (
+                _("Photos is configured to import photos to your home directory.\n" +
+                    "We recommend changing this in <span weight=\"bold\">Edit %s Preferences</span>.\n" +
+                    "Do you want to continue importing photos?"
+                ).printf ("▸"),
+                _("_Import"),
+                _("Library Location")
+            );
 
             if (response == Gtk.ResponseType.CANCEL)
                 return;


### PR DESCRIPTION
* Use Granite.MessageDialog
* Parent is always `AppWindow.get_instance ()`, so we don't need to ask it as an arg
* Use built-in cancel