### PR TITLE
Move negate_affirm_all_cancel_question to Exporter

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -191,22 +191,6 @@ public abstract class AppWindow : PageWindow {
         return (Gtk.ResponseType) response;
     }
 
-    public static Gtk.ResponseType negate_affirm_all_cancel_question (string message,
-            string negative, string affirmative, string affirmative_all, string? title = null,
-            Gtk.Window? parent = null) {
-        Gtk.MessageDialog dialog = new Gtk.MessageDialog ((parent != null) ? parent : get_instance (),
-                Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE, "%s", message);
-        dialog.title = (title != null) ? title : _ (Resources.APP_TITLE);
-        dialog.add_buttons (negative, Gtk.ResponseType.NO, affirmative, Gtk.ResponseType.YES,
-                            affirmative_all, Gtk.ResponseType.APPLY,  _ ("_Cancel"), Gtk.ResponseType.CANCEL);
-
-        int response = dialog.run ();
-
-        dialog.destroy ();
-
-        return (Gtk.ResponseType) response;
-    }
-
     public static void database_error (DatabaseError err) {
         panic (_ ("A fatal error occurred when accessing Photos' library.  Photos cannot continue.\n\n%s").printf (
                    err.message));

--- a/src/Exporter.vala
+++ b/src/Exporter.vala
@@ -326,9 +326,24 @@ public class ExporterUI {
 
     private Exporter.Overwrite on_export_overwrite (Exporter exporter, File file) {
         progress_dialog.set_modal (false);
-        string question = _ ("File %s already exists.  Replace?").printf (file.get_basename ());
-        Gtk.ResponseType response = AppWindow.negate_affirm_all_cancel_question (question,
-                                    _ ("_Skip"), _ ("_Replace"), _ ("Replace _All"), _ ("Export"));
+
+        var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+            _("Export"),
+            _("File %s already exists.  Replace?").printf (file.get_basename ()),
+            "dialog-question",
+            Gtk.ButtonsType.NONE
+        );
+        dialog.transient_for = AppWindow.get_instance ();
+        dialog.add_buttons (
+            _("_Skip"), Gtk.ResponseType.NO,
+            _("Replace _All"), Gtk.ResponseType.APPLY,
+            _("_Cancel"), Gtk.ResponseType.CANCEL
+        );
+        var replace_button = (Gtk.Button) dialog.add_button (_("_Replace"), Gtk.ResponseType.YES);
+        replace_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+
+        int response = dialog.run ();
+        dialog.destroy ();
 
         progress_dialog.set_modal (true);
 


### PR DESCRIPTION
This dialog is only used once, so just move it where it's used. Also use Granite.MessageDialog

## BEFORE
![screenshot from 2018-08-31 10 07 07 2x](https://user-images.githubusercontent.com/7277719/44926382-147dd500-ad06-11e8-933c-a2b04f8679ee.png)

## AFTER
![screenshot from 2018-08-31 10 07 48 2x](https://user-images.githubusercontent.com/7277719/44926383-15166b80-ad06-11e8-905c-c93deec34733.png)
