### PR TITLE
AppWindow: combine error and error_with_title

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -157,18 +157,14 @@ public abstract class AppWindow : PageWindow {
         return fullscreen_window;
     }
 
-    public static void error_message (string message, Gtk.Window? parent = null) {
-        error_message_with_title (_ (Resources.APP_TITLE), message, parent);
-    }
-
-    public static void error_message_with_title (string title, string message, Gtk.Window? parent = null) {
+    public static void error_message (string title, string? message = null, Gtk.Window? parent = null) {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
             title,
             message,
             "dialog-error",
             Gtk.ButtonsType.CLOSE
         );
-        dialog.transient_for = (parent != null) ? parent : get_instance ();
+        dialog.transient_for = parent ?? get_instance ();
         dialog.run ();
         dialog.destroy ();
     }
@@ -198,7 +194,7 @@ public abstract class AppWindow : PageWindow {
 
     public static void panic (string msg) {
         critical (msg);
-        error_message (msg);
+        error_message (msg, null);
 
         Application.get_instance ().panic ();
     }
@@ -220,7 +216,7 @@ public abstract class AppWindow : PageWindow {
         try {
             AppWindow.get_instance ().show_file_uri (media.get_master_file ());
         } catch (Error err) {
-            AppWindow.error_message (Resources.jump_to_file_failed (err));
+            error_message (Resources.jump_to_file_failed (err));
         }
     }
 

--- a/src/Dialogs/Dialogs.vala
+++ b/src/Dialogs/Dialogs.vala
@@ -945,7 +945,7 @@ public void remove_from_app (Gee.Collection<MediaSource> sources, string dialog_
                 ngettext ("The photo or video cannot be deleted.",
                           "%d photos/videos cannot be deleted.",
                           num_not_deleted).printf (num_not_deleted);
-            AppWindow.error_message_with_title (dialog_title, delete_failed_message, AppWindow.get_instance ());
+            AppWindow.error_message (dialog_title, delete_failed_message);
         }
     }
 

--- a/src/SlideshowPage.vala
+++ b/src/SlideshowPage.vala
@@ -157,7 +157,7 @@ class SlideshowPage : SinglePhotoPage {
 
                 // An entire slideshow set might be missing, so check for a loop.
                 if ((next == start && next != current) || next == current) {
-                    AppWindow.error_message (_ ("All photo source files are missing."), get_container ());
+                    AppWindow.error_message (_("All photo source files are missing."), null, get_container ());
                     AppWindow.get_instance ().end_fullscreen ();
 
                     next = null;

--- a/src/publishing/PublishingUI.vala
+++ b/src/publishing/PublishingUI.vala
@@ -402,10 +402,9 @@ public class PublishingDialog : Gtk.Dialog {
         if (avail_services.length == 0) {
             // There are no enabled publishing services that accept this media type,
             // warn the user.
-            AppWindow.error_message_with_title (
+            AppWindow.error_message (
                 _("Unable to publish"),
-                _("Photos cannot publish the selected items because you do not have a compatible publishing plugin enabled. To correct this, choose <b>Edit %s Preferences</b> and enable one or more of the publishing plugins on the <b>Plugins</b> tab.").printf ("▸"),
-                null
+                _("Photos cannot publish the selected items because you do not have a compatible publishing plugin enabled. To correct this, choose <b>Edit %s Preferences</b> and enable one or more of the publishing plugins on the <b>Plugins</b> tab.").printf ("▸")
             );
 
             return;


### PR DESCRIPTION
These aren't that different and can be combined with minimal effort. Using the app name as the primary text in a dialog is not useful.