### PR TITLE
MediaPage: Remove unused sidebar button properties

### DIFF
--- a/src/MediaPage.vala
+++ b/src/MediaPage.vala
@@ -803,11 +803,9 @@ public abstract class MediaPage : CheckerboardPage {
     }
 
     public static Gtk.ToolButton create_sidebar_button () {
-        var show_sidebar_button = new Gtk.ToolButton (null,null);
-        show_sidebar_button.set_icon_name (Resources.SHOW_PANE);
-        show_sidebar_button.set_label (Resources.TOGGLE_METAPANE_LABEL);
-        show_sidebar_button.set_tooltip_text (Resources.TOGGLE_METAPANE_TOOLTIP);
-        show_sidebar_button.is_important = true;
+        var show_sidebar_button = new Gtk.ToolButton (null, null);
+        show_sidebar_button.icon_name = Resources.SHOW_PANE;
+        show_sidebar_button.tooltip_text = Resources.TOGGLE_METAPANE_TOOLTIP;
         return show_sidebar_button;
     }
 }

--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -205,11 +205,9 @@ public const string DUPLICATE_PHOTO_TOOLTIP = _("Make a duplicate of the photo")
 public const string EXPORT_MENU = _("_Export…");
 
 public const string TOGGLE_METAPANE_MENU = _("_Show info panel");
-public const string TOGGLE_METAPANE_LABEL = _("Show info panel");
 public const string TOGGLE_METAPANE_TOOLTIP = _("Show info panel");
 
 public const string UNTOGGLE_METAPANE_MENU = _("_Hide info panel");
-public const string UNTOGGLE_METAPANE_LABEL = _("Hide info panel");
 public const string UNTOGGLE_METAPANE_TOOLTIP = _("Hide info panel");
 
 public const string PRINT_MENU = _("_Print…");


### PR DESCRIPTION
`label` and `is_important` are not relevant here because we don't show toolbar button labels and the setting for changing button style in Gtk.Toolbar has been removed