### PR TITLE
SlideshowPage.vala: Use GObject-style construction

### DIFF
--- a/src/SlideshowPage.vala
+++ b/src/SlideshowPage.vala
@@ -22,8 +22,6 @@ class SlideshowPage : SinglePhotoPage {
     private const int READAHEAD_COUNT = 5;
     private const int CHECK_ADVANCE_MSEC = 250;
 
-    private SourceCollection sources;
-    private ViewCollection controller;
     private Photo current;
     private Gtk.ToolButton play_pause_button;
     private PixbufCache cache = null;
@@ -36,22 +34,28 @@ class SlideshowPage : SinglePhotoPage {
 
     public signal void hide_toolbar ();
 
+    public SourceCollection sources { get; construct; }
+    public ViewCollection controller { get; construct; }
+
     public SlideshowPage (SourceCollection sources, ViewCollection controller, Photo start) {
-        base (_("Slideshow"), true);
+        Object (
+            controller: controller,
+            page_name: _("Slideshow"),
+            scale_up_to_viewport: true,
+            sources: sources
+        );
 
-        this.sources = sources;
-        this.controller = controller;
+        current = start;
+    }
 
+    construct {
         Gee.Collection<string> pluggables = TransitionEffectsManager.get_instance ().get_effect_ids ();
         Gee.ArrayList<string> a = new Gee.ArrayList<string> ();
         a.add_all (pluggables);
         a.remove (NullTransitionDescriptor.EFFECT_ID);
         a.remove (RandomEffectDescriptor.EFFECT_ID);
         transitions = a.to_array ();
-        current = start;
-    }
 
-    construct {
         slideshow_settings = new GLib.Settings (GSettingsConfigurationEngine.SLIDESHOW_PREFS_SCHEMA_NAME);
         slideshow_settings.changed.connect (() => update_transition_effect ());
 


### PR DESCRIPTION
Almost, because Photos throws some other error about `current`, so it needs some more work afterwards