### PR TITLE
Fix settings menu shortcuts and labels

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -66,24 +66,6 @@ public abstract class AppWindow : PageWindow {
         // although there are multiple AppWindow types, only one may exist per-process
         assert (instance == null);
         instance = this;
-
-        // Because the first UIManager to associated with an ActionGroup claims the accelerators,
-        // need to create the AppWindow's ActionGroup early on and add it to an application-wide
-        // UIManager.  In order to activate those accelerators, we need to create a dummy UI string
-        // that lists all the common actions.  We build it on-the-fly from the actions associated
-        // with each ActionGroup while we're adding the groups to the UIManager.
-        common_action_groups = create_common_action_groups ();
-        foreach (Gtk.ActionGroup group in common_action_groups)
-            ui.insert_action_group (group, 0);
-
-        try {
-            ui.add_ui_from_string (build_dummy_ui_string (common_action_groups), -1);
-        } catch (Error err) {
-            error ("Unable to add AppWindow UI: %s", err.message);
-        }
-
-        ui.ensure_update ();
-        add_accel_group (ui.get_accel_group ());
     }
 
     construct {
@@ -122,6 +104,24 @@ public abstract class AppWindow : PageWindow {
         Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         window_settings = new GLib.Settings (GSettingsConfigurationEngine.WINDOW_PREFS_SCHEMA_NAME);
+
+        // Because the first UIManager to associated with an ActionGroup claims the accelerators,
+        // need to create the AppWindow's ActionGroup early on and add it to an application-wide
+        // UIManager.  In order to activate those accelerators, we need to create a dummy UI string
+        // that lists all the common actions.  We build it on-the-fly from the actions associated
+        // with each ActionGroup while we're adding the groups to the UIManager.
+        common_action_groups = create_common_action_groups ();
+        foreach (Gtk.ActionGroup group in common_action_groups)
+            ui.insert_action_group (group, 0);
+
+        try {
+            ui.add_ui_from_string (build_dummy_ui_string (common_action_groups), -1);
+        } catch (Error err) {
+            error ("Unable to add AppWindow UI: %s", err.message);
+        }
+
+        ui.ensure_update ();
+        add_accel_group (ui.get_accel_group ());
     }
 
     protected abstract void on_fullscreen ();

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -157,9 +157,12 @@ public class LibraryWindow : AppWindow {
 
         var import_menu_item = new Gtk.MenuItem ();
         import_menu_item.related_action = get_common_action ("CommonFileImport");
+        import_menu_item.label = _("_Import From Folder…");
+        import_menu_item.use_underline = true;
 
         var preferences_menu_item = new Gtk.MenuItem ();
         preferences_menu_item.related_action = get_common_action ("CommonPreferences");
+        preferences_menu_item.label = _("Preferences");
 
         var settings_menu = new Gtk.Menu ();
         settings_menu.add (import_menu_item);
@@ -287,9 +290,9 @@ public class LibraryWindow : AppWindow {
     }
 
     private Gtk.ActionEntry[] create_common_actions () {
-        Gtk.ActionEntry import = { "CommonFileImport", null, _("Import From Folder…"), "<Ctrl>I", null, on_file_import };
+        Gtk.ActionEntry import = { "CommonFileImport", null, null, "<Ctrl>I", null, on_file_import };
         Gtk.ActionEntry sort = { "CommonSortEvents", null,  _("Sort _Events"), null, null, null };
-        Gtk.ActionEntry preferences = { "CommonPreferences", null, _("Preferences"), null, null, on_preferences };
+        Gtk.ActionEntry preferences = { "CommonPreferences", null, null, null, null, on_preferences };
         Gtk.ActionEntry jump_to_event = { "CommonJumpToEvent", null, _("View Eve_nt for Photo"), null, null, on_jump_to_event };
         Gtk.ActionEntry find = { "CommonFind", null, null, null, null, on_find };
 

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -157,11 +157,9 @@ public class LibraryWindow : AppWindow {
 
         var import_menu_item = new Gtk.MenuItem ();
         import_menu_item.related_action = get_common_action ("CommonFileImport");
-        import_menu_item.label = _("_Import From Folder…");
 
         var preferences_menu_item = new Gtk.MenuItem ();
         preferences_menu_item.related_action = get_common_action ("CommonPreferences");
-        preferences_menu_item.label = _("_Preferences");
 
         var settings_menu = new Gtk.Menu ();
         settings_menu.add (import_menu_item);
@@ -289,9 +287,9 @@ public class LibraryWindow : AppWindow {
     }
 
     private Gtk.ActionEntry[] create_common_actions () {
-        Gtk.ActionEntry import = { "CommonFileImport", null, null, "<Ctrl>I", null, on_file_import };
+        Gtk.ActionEntry import = { "CommonFileImport", null, _("Import From Folder…"), "<Ctrl>I", null, on_file_import };
         Gtk.ActionEntry sort = { "CommonSortEvents", null,  _("Sort _Events"), null, null, null };
-        Gtk.ActionEntry preferences = { "CommonPreferences", null, null, null, null, on_preferences };
+        Gtk.ActionEntry preferences = { "CommonPreferences", null, _("Preferences"), null, null, on_preferences };
         Gtk.ActionEntry jump_to_event = { "CommonJumpToEvent", null, _("View Eve_nt for Photo"), null, null, on_jump_to_event };
         Gtk.ActionEntry find = { "CommonFind", null, null, null, null, on_find };
 

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -162,7 +162,8 @@ public class LibraryWindow : AppWindow {
 
         var preferences_menu_item = new Gtk.MenuItem ();
         preferences_menu_item.related_action = get_common_action ("CommonPreferences");
-        preferences_menu_item.label = _("Preferences");
+        preferences_menu_item.label = _("_Preferences");
+        preferences_menu_item.use_underline = true;
 
         var settings_menu = new Gtk.Menu ();
         settings_menu.add (import_menu_item);


### PR DESCRIPTION
Fixes #436.

Moves setting up action groups to the constructor so that they get initialized before `LibraryWindow` wants to access them and moves menuitem labels to the action entries themselves.