### PR TITLE
Pack buttons in instance classes to fix order

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -38,8 +38,8 @@ public abstract class AppWindow : PageWindow {
     private int pos_y = 0;
     protected Gtk.HeaderBar header;
 
-    private Gtk.Button redo_btn;
-    private Gtk.Button undo_btn;
+    protected Gtk.Button redo_btn;
+    protected Gtk.Button undo_btn;
 
     protected GLib.Settings window_settings;
 
@@ -99,8 +99,6 @@ public abstract class AppWindow : PageWindow {
 
         header = new Gtk.HeaderBar ();
         header.show_close_button = true;
-        header.pack_end (redo_btn);
-        header.pack_end (undo_btn);
 
         icon_name = "multimedia-photo-manager";
         title = _(Resources.APP_TITLE);

--- a/src/direct/DirectWindow.vala
+++ b/src/direct/DirectWindow.vala
@@ -53,6 +53,8 @@ public class DirectWindow : AppWindow {
         header.has_subtitle = false;
         header.pack_start (save_btn);
         header.pack_start (save_as_btn);
+        header.pack_end (redo_btn);
+        header.pack_end (undo_btn);
     }
 
     construct {

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -176,6 +176,8 @@ public class LibraryWindow : AppWindow {
         settings.show_all ();
 
         header.pack_end (settings);
+        header.pack_end (redo_btn);
+        header.pack_end (undo_btn);
         header.set_custom_title (top_display);
 
         bind_property ("title", top_display, "title");


### PR DESCRIPTION
Fixes headerbar button order by packing buttons in the instance classes instead of the abstract class