### PR TITLE
LibraryWindow: Fix searchbar placement

### DIFF
--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -179,10 +179,10 @@ public class LibraryWindow : AppWindow {
         search_entry = new SearchFilterEntry ();
         search_entry.valign = Gtk.Align.CENTER;
 
-        header.pack_end (search_entry);
         header.pack_end (settings);
         header.pack_end (redo_btn);
         header.pack_end (undo_btn);
+        header.pack_end (search_entry);
         header.set_custom_title (top_display);
 
         sidebar_tree = new Sidebar.Tree (DND_TARGET_ENTRIES, Gdk.DragAction.ASK, external_drop_handler);


### PR DESCRIPTION
Not sure how this happened, but this fixes the searchbar so that it's in the right place in the headerbar