### PR TITLE
appdata: replace remaining <_li> tags with plain <li>

### DIFF
--- a/data/io.elementary.photos.appdata.xml.in
+++ b/data/io.elementary.photos.appdata.xml.in
@@ -34,24 +34,24 @@
     <release version="2.6.0" date="2018-06-20" urgency="medium">
       <description>
         <ul>
-          <_li>Search box no longer loses focus after character input</_li>
-          <_li>Colorized tint and temperature scales</_li>
-          <_li>Add zoom to fit page button</_li>
-          <_li>Various UI fixes and improvements</_li>
-          <_li>Minor bug fixes</_li>
-          <_li>Translation updates</_li>
+          <li>Search box no longer loses focus after character input</li>
+          <li>Colorized tint and temperature scales</li>
+          <li>Add zoom to fit page button</li>
+          <li>Various UI fixes and improvements</li>
+          <li>Minor bug fixes</li>
+          <li>Translation updates</li>
         </ul>
       </description>
     </release>
     <release version="0.2.5" date="2018-06-20" urgency="medium">
       <description>
         <ul>
-          <_li>Prefer dark theme</_li>
-          <_li>WebP format support</_li>
-          <_li>Improved HiDPI support</_li>
-          <_li>Various UI fixes and improvements</_li>
-          <_li>Minor bug fixes</_li>
-          <_li>Translation updates</_li>
+          <li>Prefer dark theme</li>
+          <li>WebP format support</li>
+          <li>Improved HiDPI support</li>
+          <li>Various UI fixes and improvements</li>
+          <li>Minor bug fixes</li>
+          <li>Translation updates</li>
         </ul>
       </description>
     </release>


### PR DESCRIPTION
It looks like those remaning `<_li>` tags were left there by mistake. Changing them to `<li>` fixes appdata validation on fedora.

Fixes #459