### PR TITLE
photos/PhotoMetadata: fix missing line accidentally dropped with PR #498

### DIFF
--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -197,6 +197,7 @@ public class PhotoMetadata : MediaMetadata {
 #else
         exiv2.from_app1_segment (buffer, length);
 #endif
+        exif = Exif.Data.new_from_data (buffer, length);
         source_name = "<app1 segment %d bytes>".printf (length);
     }
 


### PR DESCRIPTION
PR #498 accidentally dropped an unrelated line completely when wrapping the GExiv2 code inside a conditional. This PR re-introduces the missing line.