### PR TITLE
Drop styles that are already in system stylesheet

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -22,6 +22,24 @@
     color: @text_color;
 }
 
+scale.temperature trough {
+    background-image:
+        linear-gradient(
+            to right,
+            @BLUEBERRY_500,
+            @BANANA_500
+        );
+}
+
+scale.temperature:dir(rtl) trough {
+    background-image:
+        linear-gradient(
+            to left,
+            @BLUEBERRY_500,
+            @BANANA_500
+        );
+}
+
 scale.tint trough {
     background-image:
         linear-gradient(
@@ -40,11 +58,11 @@ scale.tint:dir(rtl) trough {
         );
 }
 
-scale.tint trough {
+scale.tint trough,
+scale.temperature trough {
     box-shadow:
         inset 0 0 0 1px alpha (#000, 0.7),
         inset 0 1px 0 alpha (#000, 0.7),
         inset 0 2px 0 alpha (#fff, 0.15),
         0 1px 0 0 alpha (@bg_highlight_color, 0.3);
 }
-

--- a/data/application.css
+++ b/data/application.css
@@ -1,57 +1,3 @@
-.solid-checkerboard-layout {
-    background-color: #383e41;
-}
-
-.checkerboard-layout {
-    background-color: #383e41;
-    background-image:
-        linear-gradient(
-            45deg,
-            alpha (
-                #000,
-                0.1
-            ) 25%,
-            transparent 25%,
-            transparent 75%,
-            alpha (
-                #000,
-                0.1
-            ) 75%,
-            alpha (
-                #000,
-                0.1
-            )
-        ),
-        linear-gradient(
-            45deg,
-            alpha (
-                #000,
-                0.1
-            ) 25%,
-            transparent 25%,
-            transparent 75%,
-            alpha (
-                #000,
-                0.1
-            ) 75%,
-            alpha (
-                #000,
-                0.1
-            )
-        );
-    background-size: 24px 24px;
-    background-position: 0 0, 12px 12px;
-}
-
-.solid-checkboard-layout .item {
-    background-color: #eee;
-}
-
-.solid-checkerboard-layout .label {
-    color: #c0c6c4;
-    text-shadow: 0 1px 2px alpha(#000, 0.5);
-}
-
 .event {
     border: 3px solid #f4f4f4;
     border-radius: 6px;
@@ -76,24 +22,6 @@
     color: @text_color;
 }
 
-scale.temperature trough {
-    background-image:
-        linear-gradient(
-            to right,
-            @BLUEBERRY_500,
-            @BANANA_500
-        );
-}
-
-scale.temperature:dir(rtl) trough {
-    background-image:
-        linear-gradient(
-            to left,
-            @BLUEBERRY_500,
-            @BANANA_500
-        );
-}
-
 scale.tint trough {
     background-image:
         linear-gradient(
@@ -112,11 +40,11 @@ scale.tint:dir(rtl) trough {
         );
 }
 
-scale.tint trough,
-scale.temperature trough {
+scale.tint trough {
     box-shadow:
         inset 0 0 0 1px alpha (#000, 0.7),
         inset 0 1px 0 alpha (#000, 0.7),
         inset 0 2px 0 alpha (#fff, 0.15),
         0 1px 0 0 alpha (@bg_highlight_color, 0.3);
 }
+

--- a/src/Checkerboard/CheckerboardLayout.vala
+++ b/src/Checkerboard/CheckerboardLayout.vala
@@ -85,9 +85,6 @@ public class CheckerboardLayout : Gtk.DrawingArea {
         view.items_selected.connect (on_items_selection_changed);
         view.items_unselected.connect (on_items_selection_changed);
 
-        weak Gtk.StyleContext style_context = get_style_context ();
-        style_context.add_class ("solid-checkerboard-layout");
-
         // CheckerboardItems offer tooltips
         has_tooltip = true;
     }


### PR DESCRIPTION
It looks like we were carrying some custom styles from when Photos was a light app, but we wanted the canvas behind images to be dark. Now that we're using the dark style, we can drop a lot. Plus, checkerboard and temperature scales are in the system stylesheet.