### PR TITLE
Back to the previous collection page with Alt + Left arrow

### DIFF
--- a/src/Views/LibraryPhotoPage.vala
+++ b/src/Views/LibraryPhotoPage.vala
@@ -707,7 +707,7 @@ public class LibraryPhotoPage : EditingHostPage {
         }
     }
 
-    private void return_to_collection () {
+    protected override void return_to_collection () {
         // Return to the previous page if it exists.
         if (null != return_page)
             LibraryWindow.get_app ().switch_to_page (return_page);

--- a/src/Views/SinglePhotoPage.vala
+++ b/src/Views/SinglePhotoPage.vala
@@ -470,6 +470,9 @@ public abstract class SinglePhotoPage : Page {
         return popup_context_menu (get_page_context_menu ());
     }
 
+    protected virtual void return_to_collection () {
+    }
+
     protected virtual void on_previous_photo () {
     }
 
@@ -482,10 +485,18 @@ public abstract class SinglePhotoPage : Page {
         // we staunch the supply of new photos to under a quarter second (#533)
         bool nav_ok = (event.time - last_nav_key) > 200;
 
+        Gdk.ModifierType modifier_type;
+        event.get_state (out modifier_type);
+        bool has_alt_modifier = modifier_type == Gdk.ModifierType.MOD1_MASK;
+
         bool handled = true;
         switch (Gdk.keyval_name (event.keyval)) {
         case "Left":
         case "KP_Left":
+            if (has_alt_modifier) {
+                return_to_collection ();
+            }
+
             if (nav_ok) {
                 on_previous_photo ();
                 last_nav_key = event.time;
@@ -495,6 +506,10 @@ public abstract class SinglePhotoPage : Page {
         case "Right":
         case "KP_Right":
         case "space":
+            if (has_alt_modifier) {
+                break;
+            }
+
             if (nav_ok) {
                 on_next_photo ();
                 last_nav_key = event.time;

--- a/src/Views/SinglePhotoPage.vala
+++ b/src/Views/SinglePhotoPage.vala
@@ -485,9 +485,7 @@ public abstract class SinglePhotoPage : Page {
         // we staunch the supply of new photos to under a quarter second (#533)
         bool nav_ok = (event.time - last_nav_key) > 200;
 
-        Gdk.ModifierType modifier_type;
-        event.get_state (out modifier_type);
-        bool has_alt_modifier = modifier_type == Gdk.ModifierType.MOD1_MASK;
+        bool has_alt_modifier = (event.state & Gdk.ModifierType.MOD1_MASK) != 0;
 
         bool handled = true;
         switch (Gdk.keyval_name (event.keyval)) {


### PR DESCRIPTION
Fixes #346

## The Behavior with master

* `Left arrow`: Back to the previous photo
* `Right arrow`: Go to the next photo
* `Alt + Left arrow`: Back to the previous photo
* `Alt + Right arrow`: Go to the next photo

## The Behavior with this branch

* `Left arrow`: Back to the previous photo
* `Right arrow`: Go to the next photo
* `Alt + Left arrow`: **Back to the previous collection page**
* `Alt + Right arrow`: **Do nothing**
