### PR TITLE
Remove python-scour from the dependency list

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Build-Depends: debhelper (>= 10.5.1),
                libxml2 (>= 2.6.32),
                libxml2-utils,
                meson,
-               python-scour,
                valac (>= 0.18.0)
 Standards-Version: 4.1.1
 Homepage: https://github.com/elementary/photos


### PR DESCRIPTION
It is not used anymore