### PR TITLE
Save/restore the status of the library window position

### DIFF
--- a/data/io.elementary.photos.gschema.xml
+++ b/data/io.elementary.photos.gschema.xml
@@ -148,22 +148,20 @@
 <schema id="io.elementary.photos.preferences.window" path="/io/elementary/photos/preferences/window/">
     <key name="library-maximize" type="b">
         <default>false</default>
-        <summary>maximize library window</summary>
+        <summary>Maximize library window</summary>
         <description>True if library application is maximized, false otherwise.</description>
     </key>
 
-    <key name="library-width" type="i">
-        <default>1000</default>
-        <summary>width of library window</summary>
-        <description>The last recorded width of the library application window.</description>
-    </key>
+    <key name="library-position" type="(ii)">
+      <default>(-1, -1)</default>
+      <summary>Library window position</summary>
+      <description>Most recent library window position (x, y)</description>
 
-    <key name="library-height" type="i">
-        <default>680</default>
-        <summary>height of library window</summary>
-        <description>The last recorded height of the library application window.</description>
-    </key>
-
+    <key name="library-size" type="(ii)">
+      <default>(1000, 680)</default>
+      <summary>Library window size</summary>
+      <description>Most recent library window size (width, height)</description>
+   
     <key name="direct-maximize" type="b">
         <default>false</default>
         <summary>maximize direct-edit window</summary>

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -144,8 +144,8 @@ public class LibraryWindow : AppWindow {
 
     construct {
         set_default_size (
-            window_settings.get_int ("library-position"),
-            window_settings.get_int ("library-size")
+            window_settings.get ("library-position", "(ii)", out window_x, out window_y);
+            window_settings.get ("library-size", "(ii)", out width, out height);
         );
 
         if (window_settings.get_boolean ("library-maximize")) {
@@ -513,8 +513,8 @@ public class LibraryWindow : AppWindow {
 
     protected override void on_quit () {
         window_settings.set_boolean ("library-maximize", is_maximized);
-        window_settings.set_int ("library-position", dimensions.position);
-        window_settings.set_int ("library-size", dimensions.size);
+        window_settings.set ("library-position", "(ii)", out window_x, out window_y);
+        window_settings.set ("library-size", "(ii)", out width, out height);
 
         base.on_quit ();
     }

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -144,8 +144,8 @@ public class LibraryWindow : AppWindow {
 
     construct {
         set_default_size (
-            window_settings.get_int ("library-width"),
-            window_settings.get_int ("library-height")
+            window_settings.get_int ("library-position"),
+            window_settings.get_int ("library-size")
         );
 
         if (window_settings.get_boolean ("library-maximize")) {
@@ -513,8 +513,8 @@ public class LibraryWindow : AppWindow {
 
     protected override void on_quit () {
         window_settings.set_boolean ("library-maximize", is_maximized);
-        window_settings.set_int ("library-width", dimensions.width);
-        window_settings.set_int ("library-height", dimensions.height);
+        window_settings.set_int ("library-position", dimensions.position);
+        window_settings.set_int ("library-size", dimensions.size);
 
         base.on_quit ();
     }


### PR DESCRIPTION
Fixes https://github.com/elementary/photos/issues/566

gschema.xml
- [x] Use common key for library window width and height ("library-size").
- [x] Add the initial key for the library window position ("library-position").

LibraryWindow.vala
- [x] Use "library-size".
- [x] Initially add the "library-position".

appdata.xml
- [ ] Update the version of Photos to 2.7.1