### PR TITLE
Fix unsafe cast warnings on compiling

### DIFF
--- a/src/Commands.vala
+++ b/src/Commands.vala
@@ -1313,7 +1313,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
 
         // this should be replaced by a first function when we migrate to Gee's List
         foreach (DataView view in iter) {
-            prev_events.set (view.source as Dateable, (view.source as MediaSource).get_event ());
+            prev_events.set ((Dateable)(view.source), ((MediaSource)(view.source)).get_event ());
 
             if (new_time == null) {
                 new_time = ((Dateable) view.source).get_exposure_time () +
@@ -1409,7 +1409,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
             set_time (photo, photo.get_exposure_time () - (time_t) time_shift);
         }
 
-        (source as MediaSource).set_event (prev_events.get (source as Dateable));
+        ((MediaSource)source).set_event (prev_events.get (source as Dateable));
     }
 }
 

--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -505,7 +505,7 @@ public class ImportPage : CheckerboardPage {
             filename = import_file.filename;
             filesize = import_file.file_size;
             metadata = (import_file is PhotoImportSource) ?
-                       (import_file as PhotoImportSource).get_metadata () : null;
+                       ((PhotoImportSource)import_file).get_metadata () : null;
             exposure_time = import_file.get_exposure_time ();
         }
 
@@ -1665,10 +1665,10 @@ public class ImportPage : CheckerboardPage {
 #endif
 
             if (import_source is VideoImportSource)
-                (import_source as VideoImportSource).update (preview);
+                ((VideoImportSource)import_source).update (preview);
 
             if (import_source is PhotoImportSource)
-                (import_source as PhotoImportSource).update (preview, preview_md5, metadata,
+                ((PhotoImportSource)import_source).update (preview, preview_md5, metadata,
                         exif_only_md5);
 
             if (associated != null) {

--- a/src/Widgets/TransitionEffectSelector.vala
+++ b/src/Widgets/TransitionEffectSelector.vala
@@ -69,7 +69,7 @@ public class TransitionEffectSelector : Gtk.ToolItem {
 
         effect_list_box = new Gtk.ListBox ();
         effect_list_box.bind_model (effect_list_store, (item) => {
-            return new LayoutRow ((item as ListStoreItem).name);
+            return new LayoutRow (((ListStoreItem)item).name);
         });
 
         effect_list_box.row_activated.connect ((row) => {


### PR DESCRIPTION
Code still has a shed load of deprecation warnings and some invalid casts reported at run-time. 