### PR TITLE
Replace deprecated time val

### DIFF
--- a/plugins/pantheon-photos-publishing-extras/TumblrPublishing.vala
+++ b/plugins/pantheon-photos-publishing-extras/TumblrPublishing.vala
@@ -1141,17 +1141,15 @@ public class TumblrPublisher : Spit.Publishing.Publisher, GLib.Object {
         }
 
         public string get_oauth_nonce () {
-            TimeVal currtime = TimeVal ();
-            currtime.get_current_time ();
-
-            return Checksum.compute_for_string (ChecksumType.MD5, currtime.tv_sec.to_string () +
-                                                currtime.tv_usec.to_string ());
+            var currtime = new DateTime.now_local ();
+            //Note: Is this random/unique enough?
+            return Checksum.compute_for_string (ChecksumType.MD5, currtime.to_unix ().to_string () +
+                                                currtime.get_microsecond ().to_string ());
         }
 
         public string get_oauth_timestamp () {
             return GLib.get_real_time ().to_string ().substring (0, 10);
         }
-
     }
 
 

--- a/plugins/pantheon-photos-publishing/FlickrPublishing.vala
+++ b/plugins/pantheon-photos-publishing/FlickrPublishing.vala
@@ -1060,11 +1060,10 @@ internal class Session : Publishing.RESTSupport.Session {
     }
 
     public string get_oauth_nonce () {
-        TimeVal currtime = TimeVal ();
-        currtime.get_current_time ();
+        var currtime = new DateTime.now_local ();
 
-        return Checksum.compute_for_string (ChecksumType.MD5, currtime.tv_sec.to_string () +
-                                            currtime.tv_usec.to_string ());
+        return Checksum.compute_for_string (ChecksumType.MD5, currtime.to_unix ().to_string () +
+                                            currtime.get_microsecond ().to_string ());
     }
 
     public string get_oauth_timestamp () {

--- a/src/AppDirs.vala
+++ b/src/AppDirs.vala
@@ -165,7 +165,7 @@ class AppDirs {
         return get_home_dir ().get_child (_ ("Pictures"));
     }
 
-    public static File get_baked_import_dir (time_t tm) {
+    public static File get_baked_import_dir (int64 tm) {
         string? pattern = "%Y" + Path.DIR_SEPARATOR_S + "%m" + Path.DIR_SEPARATOR_S + "%d"; // default
 
         DateTime date = new DateTime.from_unix_local (tm);

--- a/src/BatchImport.vala
+++ b/src/BatchImport.vala
@@ -438,7 +438,7 @@ public class BatchImport : Object {
     private int file_imports_to_perform = -1;
     private int file_imports_completed = 0;
     private Cancellable? cancellable = null;
-    private ulong last_preparing_ms = 0;
+    private int64 last_preparing_ms = 0;
     private Gee.HashSet<File> skipset;
 #if !NO_DUPE_DETECTION
     private Gee.HashMap<string, File> imported_full_md5_table = new Gee.HashMap<string, File> ();
@@ -597,13 +597,13 @@ public class BatchImport : Object {
         // only report "progress" if progress has been made (and enough time has progressed),
         // otherwise still preparing
         if (completed_bytes == 0) {
-            ulong now = now_ms ();
+            int64 now = now_ms ();
             if (now - last_preparing_ms > 250) {
                 last_preparing_ms = now;
                 preparing ();
             }
         } else if (increment_of_progress > 0) {
-            ulong now = now_ms ();
+            int64 now = now_ms ();
             if (now - last_preparing_ms > 250) {
                 last_preparing_ms = now;
                 progress (completed_bytes, total_bytes);

--- a/src/BatchImport.vala
+++ b/src/BatchImport.vala
@@ -210,9 +210,9 @@ public abstract class BatchImportJob {
         return false;
     }
 
-    // returns a non-zero time_t value if this has a valid exposure time override, returns zero
+    // returns a non-zero int64 value if this has a valid exposure time override, returns zero
     // otherwise
-    public virtual time_t get_exposure_time_override () {
+    public virtual int64 get_exposure_time_override () {
         return 0;
     }
 }

--- a/src/Commands.vala
+++ b/src/Commands.vala
@@ -1253,7 +1253,7 @@ public class AdjustDateTimePhotoCommand : SingleDataSourceCommand {
     }
 
     public override void execute () {
-        set_time (dateable, dateable.get_exposure_time () + (time_t) time_shift);
+        set_time (dateable, dateable.get_exposure_time () + (int64) time_shift);
 
         prev_event = dateable.get_event ();
 
@@ -1269,12 +1269,12 @@ public class AdjustDateTimePhotoCommand : SingleDataSourceCommand {
     }
 
     public override void undo () {
-        set_time (dateable, dateable.get_exposure_time () - (time_t) time_shift);
+        set_time (dateable, dateable.get_exposure_time () - (int64) time_shift);
 
         dateable.set_event (prev_event);
     }
 
-    private void set_time (Dateable dateable, time_t exposure_time) {
+    private void set_time (Dateable dateable, int64 exposure_time) {
         if (modify_original && dateable is Photo) {
             try {
                 ((Photo)dateable).set_exposure_time_persistent (exposure_time);
@@ -1294,8 +1294,8 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
     private Gee.Map < Dateable, Event?> prev_events;
 
     // used when photos are batch changed instead of shifted uniformly
-    private time_t? new_time = null;
-    private Gee.HashMap < Dateable, time_t?> old_times;
+    private int64? new_time = null;
+    private Gee.HashMap < Dateable, int64?> old_times;
     private Gee.ArrayList<Dateable> error_list;
 
     public AdjustDateTimePhotosCommand (Gee.Iterable<DataView> iter, int64 time_shift,
@@ -1317,12 +1317,12 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
 
             if (new_time == null) {
                 new_time = ((Dateable) view.source).get_exposure_time () +
-                           (time_t) time_shift;
+                           (int64) time_shift;
                 break;
             }
         }
 
-        old_times = new Gee.HashMap < Dateable, time_t?> ();
+        old_times = new Gee.HashMap < Dateable, int64?> ();
     }
 
     public override void execute () {
@@ -1361,7 +1361,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
         }
     }
 
-    private void set_time (Dateable dateable, time_t exposure_time) {
+    private void set_time (Dateable dateable, int64 exposure_time) {
         // set_exposure_time_persistent wouldn't work on videos,
         // since we can't actually write them from inside shotwell,
         // so check whether we're working on a Photo or a Video
@@ -1382,7 +1382,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
         Dateable dateable = ((Dateable) source);
 
         if (keep_relativity && dateable.get_exposure_time () != 0) {
-            set_time (dateable, dateable.get_exposure_time () + (time_t) time_shift);
+            set_time (dateable, dateable.get_exposure_time () + (int64) time_shift);
         } else {
             old_times.set (dateable, dateable.get_exposure_time ());
             set_time (dateable, new_time);
@@ -1406,7 +1406,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
             set_time (photo, old_times.get (photo));
             old_times.unset (photo);
         } else {
-            set_time (photo, photo.get_exposure_time () - (time_t) time_shift);
+            set_time (photo, photo.get_exposure_time () - (int64) time_shift);
         }
 
         ((MediaSource)source).set_event (prev_events.get (source as Dateable));

--- a/src/Commands.vala
+++ b/src/Commands.vala
@@ -1253,7 +1253,7 @@ public class AdjustDateTimePhotoCommand : SingleDataSourceCommand {
     }
 
     public override void execute () {
-        set_time (dateable, dateable.get_exposure_time () + (int64) time_shift);
+        set_time (dateable, dateable.get_exposure_time () + time_shift);
 
         prev_event = dateable.get_event ();
 
@@ -1269,7 +1269,7 @@ public class AdjustDateTimePhotoCommand : SingleDataSourceCommand {
     }
 
     public override void undo () {
-        set_time (dateable, dateable.get_exposure_time () - (int64) time_shift);
+        set_time (dateable, dateable.get_exposure_time () - time_shift);
 
         dateable.set_event (prev_event);
     }
@@ -1316,8 +1316,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
             prev_events.set ((Dateable)(view.source), ((MediaSource)(view.source)).get_event ());
 
             if (new_time == null) {
-                new_time = ((Dateable) view.source).get_exposure_time () +
-                           (int64) time_shift;
+                new_time = ((Dateable) view.source).get_exposure_time () + time_shift;
                 break;
             }
         }
@@ -1382,7 +1381,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
         Dateable dateable = ((Dateable) source);
 
         if (keep_relativity && dateable.get_exposure_time () != 0) {
-            set_time (dateable, dateable.get_exposure_time () + (int64) time_shift);
+            set_time (dateable, dateable.get_exposure_time () + time_shift);
         } else {
             old_times.set (dateable, dateable.get_exposure_time ());
             set_time (dateable, new_time);
@@ -1406,7 +1405,7 @@ public class AdjustDateTimePhotosCommand : MultipleDataSourceCommand {
             set_time (photo, old_times.get (photo));
             old_times.unset (photo);
         } else {
-            set_time (photo, photo.get_exposure_time () - (int64) time_shift);
+            set_time (photo, photo.get_exposure_time () - time_shift);
         }
 
         ((MediaSource)source).set_event (prev_events.get (source as Dateable));

--- a/src/Dialogs/AdjustDateTimeDialog.vala
+++ b/src/Dialogs/AdjustDateTimeDialog.vala
@@ -22,7 +22,6 @@ public class AdjustDateTimeDialog : Granite.Dialog {
     private const int64 SECONDS_IN_DAY = 60 * 60 * 24;
     private const int64 SECONDS_IN_HOUR = 60 * 60;
     private const int64 SECONDS_IN_MINUTE = 60;
-//~     private const int YEAR_OFFSET = 1900;
     private bool no_original_time = false;
 
     private const int CALENDAR_THUMBNAIL_SCALE = 1;
@@ -209,11 +208,6 @@ public class AdjustDateTimeDialog : Granite.Dialog {
     }
 
     private int64 get_time () {
-//~         Time time = Time ();
-
-//~         time.second = (int) second.get_value ();
-//~         time.minute = (int) minute.get_value ();
-
         // convert to 24 hr
         int hour = (int) hour.get_value ();
         hour = (hour == 12 && system.get_active () != TimeSystem.24HR) ? 0 : hour;
@@ -221,12 +215,9 @@ public class AdjustDateTimeDialog : Granite.Dialog {
 
         uint year, month, day;
         calendar.get_date (out year, out month, out day);
-//~         time.year = ((int) year) - YEAR_OFFSET;
-//~         time.month = (int) month;
-//~         time.day = (int) day;
-
-//~         time.isdst = -1;
-        var date_time = new DateTime.local ((int)year, (int)month, (int)day, hour, (int) minute.get_value (), second.get_value ());
+        var date_time = new DateTime.local (
+            (int) year, (int) month, (int) day, hour, (int) minute.get_value (), second.get_value ()
+        );
         return date_time.to_unix ();
     }
 

--- a/src/Dialogs/AdjustDateTimeDialog.vala
+++ b/src/Dialogs/AdjustDateTimeDialog.vala
@@ -228,10 +228,11 @@ public class AdjustDateTimeDialog : Granite.Dialog {
         bool response = false;
 
         if (run () == Gtk.ResponseType.OK) {
-            if (no_original_time)
-                time_shift = (int64) get_time ();
-            else
-                time_shift = (int64) (get_time () - original_time);
+            if (no_original_time) {
+                time_shift = get_time ();
+            } else {
+                time_shift = get_time () - original_time;
+            }
 
             keep_relativity = relativity_radio_button.get_active ();
 
@@ -264,7 +265,7 @@ public class AdjustDateTimeDialog : Granite.Dialog {
     }
 
     private void on_time_changed () {
-        int64 time_shift = ((int64) get_time () - (int64) original_time);
+        int64 time_shift = get_time () - original_time;
 
         previous_time_system = (TimeSystem) system.get_active ();
 

--- a/src/Dialogs/AdjustDateTimeDialog.vala
+++ b/src/Dialogs/AdjustDateTimeDialog.vala
@@ -22,12 +22,12 @@ public class AdjustDateTimeDialog : Granite.Dialog {
     private const int64 SECONDS_IN_DAY = 60 * 60 * 24;
     private const int64 SECONDS_IN_HOUR = 60 * 60;
     private const int64 SECONDS_IN_MINUTE = 60;
-    private const int YEAR_OFFSET = 1900;
+//~     private const int YEAR_OFFSET = 1900;
     private bool no_original_time = false;
 
     private const int CALENDAR_THUMBNAIL_SCALE = 1;
 
-    private time_t original_time;
+    private int64 original_time;
     private Gtk.Label original_time_label;
     private Gtk.Calendar calendar;
     private Gtk.SpinButton hour;
@@ -173,25 +173,25 @@ public class AdjustDateTimeDialog : Granite.Dialog {
             no_original_time = true;
         }
 
-        set_time (Time.local (original_time));
+        set_time (new DateTime.from_unix_local (original_time));
         set_original_time_label (ui_settings.get_boolean ("use-24-hour-time"));
     }
 
-    private void set_time (Time time) {
-        calendar.select_month (time.month, time.year + YEAR_OFFSET);
-        calendar.select_day (time.day);
+    private void set_time (DateTime time) {
+        calendar.select_month (time.get_month (), time.get_year ());
+        calendar.select_day (time.get_day_of_month ());
 
         if (ui_settings.get_boolean ("use-24-hour-time")) {
-            hour.set_value (time.hour);
+            hour.set_value (time.get_hour ());
             system.set_active (TimeSystem.24HR);
         } else {
-            int ampm_hour = time.hour % 12;
+            int ampm_hour = time.get_hour () % 12;
             hour.set_value ((ampm_hour == 0) ? 12 : ampm_hour);
-            system.set_active ((time.hour >= 12) ? TimeSystem.PM : TimeSystem.AM);
+            system.set_active ((time.get_hour () >= 12) ? TimeSystem.PM : TimeSystem.AM);
         }
 
-        minute.set_value (time.minute);
-        second.set_value (time.second);
+        minute.set_value (time.get_minute ());
+        second.set_value (time.get_second ());
 
         previous_time_system = (TimeSystem) system.get_active ();
     }
@@ -200,31 +200,34 @@ public class AdjustDateTimeDialog : Granite.Dialog {
         if (no_original_time)
             return;
 
-        original_time_label.set_text (_ ("Original: ") +
-                                      Time.local (original_time).format (use_24_hr_format ? _ ("%m/%d/%Y, %H:%M:%S") :
-                                              _ ("%m/%d/%Y, %I:%M:%S %p")));
+        original_time_label.set_text (
+            _ ("Original: ") +
+            (new DateTime.from_unix_local (original_time)).format (
+                use_24_hr_format ? _ ("%m/%d/%Y, %H:%M:%S") : _ ("%m/%d/%Y, %I:%M:%S %p")
+            )
+        );
     }
 
-    private time_t get_time () {
-        Time time = Time ();
+    private int64 get_time () {
+//~         Time time = Time ();
 
-        time.second = (int) second.get_value ();
-        time.minute = (int) minute.get_value ();
+//~         time.second = (int) second.get_value ();
+//~         time.minute = (int) minute.get_value ();
 
         // convert to 24 hr
         int hour = (int) hour.get_value ();
-        time.hour = (hour == 12 && system.get_active () != TimeSystem.24HR) ? 0 : hour;
-        time.hour += ((system.get_active () == TimeSystem.PM) ? 12 : 0);
+        hour = (hour == 12 && system.get_active () != TimeSystem.24HR) ? 0 : hour;
+        hour += ((system.get_active () == TimeSystem.PM) ? 12 : 0);
 
         uint year, month, day;
         calendar.get_date (out year, out month, out day);
-        time.year = ((int) year) - YEAR_OFFSET;
-        time.month = (int) month;
-        time.day = (int) day;
+//~         time.year = ((int) year) - YEAR_OFFSET;
+//~         time.month = (int) month;
+//~         time.day = (int) day;
 
-        time.isdst = -1;
-
-        return time.mktime ();
+//~         time.isdst = -1;
+        var date_time = new DateTime.local ((int)year, (int)month, (int)day, hour, (int) minute.get_value (), second.get_value ());
+        return date_time.to_unix ();
     }
 
     public bool execute (out int64 time_shift, out bool keep_relativity,

--- a/src/Dialogs/AdjustDateTimeDialog.vala
+++ b/src/Dialogs/AdjustDateTimeDialog.vala
@@ -200,9 +200,10 @@ public class AdjustDateTimeDialog : Granite.Dialog {
             return;
 
         original_time_label.set_text (
-            _ ("Original: ") +
-            (new DateTime.from_unix_local (original_time)).format (
-                use_24_hr_format ? _ ("%m/%d/%Y, %H:%M:%S") : _ ("%m/%d/%Y, %I:%M:%S %p")
+            _ ("Original: %s").printf (
+                (new DateTime.from_unix_local (original_time)).format (
+                    use_24_hr_format ? _ ("%m/%d/%Y, %H:%M:%S") : _ ("%m/%d/%Y, %I:%M:%S %p")
+                )
             )
         );
     }

--- a/src/Dialogs/Dialogs.vala
+++ b/src/Dialogs/Dialogs.vala
@@ -250,7 +250,7 @@ public string create_result_report_from_manifest (ImportManifest manifest) {
     StringBuilder builder = new StringBuilder ();
 
     string header = _ ("Import Results Report") + " (Photos " + Resources.APP_VERSION + " @ " +
-                    (new DateTime.now_local ()).to_string () + ")\n\n";
+                    (new DateTime.now_local ()).format_iso8601 () + ")\n\n";
     builder.append (header);
 
     string subhead = (ngettext ("Attempted to import %d file.", "Attempted to import %d files.",

--- a/src/Dialogs/Dialogs.vala
+++ b/src/Dialogs/Dialogs.vala
@@ -250,7 +250,7 @@ public string create_result_report_from_manifest (ImportManifest manifest) {
     StringBuilder builder = new StringBuilder ();
 
     string header = _ ("Import Results Report") + " (Photos " + Resources.APP_VERSION + " @ " +
-                    TimeVal ().to_iso8601 () + ")\n\n";
+                    (new DateTime.now_local ()).to_string () + ")\n\n";
     builder.append (header);
 
     string subhead = (ngettext ("Attempted to import %d file.", "Attempted to import %d files.",

--- a/src/Dialogs/ProgressDialog.vala
+++ b/src/Dialogs/ProgressDialog.vala
@@ -25,7 +25,7 @@ public class ProgressDialog : Granite.Dialog {
     private uint64 last_count = uint64.MAX;
     private int update_every = 1;
     private int minimum_on_screen_time_msec = 500;
-    private ulong time_started;
+    private int64 time_started;
 
     public ProgressDialog (Gtk.Window? owner, string text, Cancellable? cancellable = null) {
         this.cancellable = cancellable;

--- a/src/DirectoryMonitor.vala
+++ b/src/DirectoryMonitor.vala
@@ -297,7 +297,7 @@ public class DirectoryMonitor : Object {
 
             // get all the interesting matchable items from the supplied FileInfo
             int64 match_size = match.get_size ();
-            TimeVal match_time = match.get_modification_time ();
+            int64 match_time = match.get_modification_date_time ().to_unix ();
 
             foreach (File file in map.keys) {
                 FileInfo info = map.get (file);
@@ -310,10 +310,9 @@ public class DirectoryMonitor : Object {
                 if (match_size != info.get_size ())
                     continue;
 
-                TimeVal time = info.get_modification_time ();
-
-                if (time.tv_sec != match_time.tv_sec)
+                if (info.get_modification_date_time ().to_unix () != match_time) {
                     continue;
+                }
 
                 return file;
             }

--- a/src/DirectoryMonitor.vala
+++ b/src/DirectoryMonitor.vala
@@ -101,7 +101,7 @@ public class DirectoryMonitor : Object {
         public File? other_file;
         public FileMonitorEvent event;
         public uint position;
-        public ulong time_created_msec;
+        public int64 time_created_msec;
         public FileInfo? info = null;
         public Error? err = null;
         public bool completed = false;
@@ -1393,7 +1393,7 @@ public class DirectoryMonitor : Object {
     }
 
     private bool check_for_expired_delete_events () {
-        ulong expiration = now_ms () - DELETED_EXPIRATION_MSEC;
+        int64 expiration = now_ms () - DELETED_EXPIRATION_MSEC;
 
         bool any_deleted = false;
         bool any_expired = false;

--- a/src/FullScreenWindow.vala
+++ b/src/FullScreenWindow.vala
@@ -25,7 +25,7 @@ public class FullscreenWindow : PageWindow {
     private Gtk.Revealer revealer;
     private Gtk.Toolbar toolbar;
     private Gtk.ToggleToolButton pin_button;
-    private time_t left_toolbar_time = 0;
+    private int64 left_toolbar_time = 0;
     private bool switched_to = false;
 
     public bool auto_dismiss_toolbar { get; set; default = true; }
@@ -225,7 +225,7 @@ public class FullscreenWindow : PageWindow {
         }
 
         // see if enough time has elapsed
-        time_t now = time_t ();
+        int64 now = time_t ();
         assert (now >= left_toolbar_time);
 
         if (now - left_toolbar_time < TOOLBAR_DISMISSAL_SEC)

--- a/src/LibraryFiles.vala
+++ b/src/LibraryFiles.vala
@@ -23,12 +23,12 @@ namespace LibraryFiles {
 // Thus, when the method returns success a file may exist already, and should be overwritten.
 //
 // This function is thread safe.
-public File? generate_unique_file (string basename, MediaMetadata? metadata, time_t ts, out bool collision)
+public File? generate_unique_file (string basename, MediaMetadata? metadata, int64 ts, out bool collision)
 throws Error {
     // use exposure timestamp over the supplied one (which probably comes from the file's
     // modified time, or is simply time ()), unless it's zero, in which case use current time
 
-    time_t timestamp = ts;
+    int64 timestamp = ts;
     if (metadata != null) {
         MetadataDateTime? date_time = metadata.get_creation_date_time ();
         if (date_time != null)
@@ -59,7 +59,7 @@ throws Error {
 
 // This function is thread-safe.
 private File duplicate (File src, FileProgressCallback? progress_callback, bool blacklist) throws Error {
-    time_t timestamp = 0;
+    int64 timestamp = 0;
     try {
         timestamp = query_file_modified (src);
     } catch (Error err) {

--- a/src/LibraryMonitor.vala
+++ b/src/LibraryMonitor.vala
@@ -230,7 +230,7 @@ public class LibraryMonitor : DirectoryMonitor {
     private Gee.HashSet<File> pending_imports = new Gee.HashSet<File> (file_hash, file_equal);
     private Gee.ArrayList<BatchImport> batch_import_queue = new Gee.ArrayList<BatchImport> ();
     private BatchImportRoll current_import_roll = null;
-    private time_t last_import_roll_use = 0;
+    private int64 last_import_roll_use = 0;
     private BatchImport current_batch_import = null;
     private int checksums_completed = 0;
     private int checksums_total = 0;
@@ -601,7 +601,7 @@ public class LibraryMonitor : DirectoryMonitor {
         // If no import roll, or it's been over IMPORT_ROLL_QUIET_SEC since using the last one,
         // create a new one.  This allows for multiple files to come in back-to-back and be
         // imported on the same roll.
-        time_t now = (time_t) now_sec ();
+        int64 now = (int64) now_sec ();
         if (current_import_roll == null || (now - last_import_roll_use) >= IMPORT_ROLL_QUIET_SEC)
             current_import_roll = new BatchImportRoll ();
         last_import_roll_use = now;

--- a/src/LibraryMonitor.vala
+++ b/src/LibraryMonitor.vala
@@ -601,9 +601,11 @@ public class LibraryMonitor : DirectoryMonitor {
         // If no import roll, or it's been over IMPORT_ROLL_QUIET_SEC since using the last one,
         // create a new one.  This allows for multiple files to come in back-to-back and be
         // imported on the same roll.
-        int64 now = (int64) now_sec ();
-        if (current_import_roll == null || (now - last_import_roll_use) >= IMPORT_ROLL_QUIET_SEC)
+        int64 now = now_sec ();
+        if (current_import_roll == null || (now - last_import_roll_use) >= IMPORT_ROLL_QUIET_SEC) {
             current_import_roll = new BatchImportRoll ();
+        }
+
         last_import_roll_use = now;
 
         Gee.ArrayList<BatchImportJob> jobs = new Gee.ArrayList<BatchImportJob> ();

--- a/src/MediaDataRepresentation.vala
+++ b/src/MediaDataRepresentation.vala
@@ -20,10 +20,10 @@
 public class BackingFileState {
     public string filepath;
     public int64 filesize;
-    public time_t modification_time;
+    public int64 modification_time;
     public string? md5;
 
-    public BackingFileState (string filepath, int64 filesize, time_t modification_time, string? md5) {
+    public BackingFileState (string filepath, int64 filesize, int64 modification_time, string? md5) {
         this.filepath = filepath;
         this.filesize = filesize;
         this.modification_time = modification_time;
@@ -165,7 +165,7 @@ public abstract class MediaSource : ThumbnailSource, Indexable {
     public abstract File get_master_file ();
     public abstract uint64 get_master_filesize ();
     public abstract uint64 get_filesize ();
-    public abstract time_t get_timestamp ();
+    public abstract int64 get_timestamp ();
 
     // Must return at least one, for the master file.
     public abstract BackingFileState[] get_backing_files_state ();
@@ -268,7 +268,7 @@ public abstract class MediaSource : ThumbnailSource, Indexable {
         controller.commit ();
     }
 
-    public abstract time_t get_exposure_time ();
+    public abstract int64 get_exposure_time ();
 
     public abstract ImportID get_import_id ();
 }

--- a/src/MediaInterfaces.vala
+++ b/src/MediaInterfaces.vala
@@ -222,7 +222,7 @@ public interface Monitorable : MediaSource {
 // from Photo to here in order to add this capability to videos. It should
 // fire a "metadata:exposure-time" alteration when called.
 public interface Dateable : MediaSource {
-    public abstract void set_exposure_time (time_t target_time);
+    public abstract void set_exposure_time (int64 target_time);
 
-    public abstract time_t get_exposure_time ();
+    public abstract int64 get_exposure_time ();
 }

--- a/src/MediaMetadata.vala
+++ b/src/MediaMetadata.vala
@@ -129,7 +129,7 @@ public class MetadataDateTime {
 //~         tm.month--;
 //~         tm.isdst = -1;
 
-        var date_time = new DateTime.utc (year, month, day, hour, minute, (double)second);
+        var date_time = new DateTime.local (year, month, day, hour, minute, (double)second);
 //~         timestamp = tm.mktime ();
         timestamp = date_time.to_unix ();
 

--- a/src/MediaMetadata.vala
+++ b/src/MediaMetadata.vala
@@ -58,7 +58,6 @@ public errordomain MetadataDateTimeError {
 }
 
 public class MetadataDateTime {
-//~     private int64 timestamp;
     private int64 timestamp;
 
     public MetadataDateTime (int64 timestamp) {
@@ -71,12 +70,10 @@ public class MetadataDateTime {
     }
 
     public MetadataDateTime.from_xmp (string label) throws MetadataDateTimeError {
-//~         TimeVal time_val = TimeVal ();
         DateTime? date_time = new DateTime.from_iso8601 (label, null);
         if (date_time == null)
             throw new MetadataDateTimeError.INVALID_FORMAT ("%s is not XMP format date/time", label);
 
-//~         timestamp = time_val.tv_sec;
         timestamp = date_time.to_unix ();
     }
 
@@ -85,16 +82,11 @@ public class MetadataDateTime {
     }
 
     public string get_exif_label () {
-//~         return Time.local (timestamp).format ("%Y:%m:%d %H:%M:%S");
         return (new DateTime.from_unix_utc (timestamp)).format ("%Y:%m:%d %H:%M:%S");
     }
 
     public string get_xmp_label () {
-//~         TimeVal time_val = TimeVal ();
-//~         time_val.tv_sec = timestamp;
-//~         time_val.tv_usec = 0;
         var date_time = new DateTime.from_unix_utc (timestamp);
-//~         return time_val.to_iso8601 ();
         return date_time.format_iso8601 ();
     }
 
@@ -125,12 +117,7 @@ public class MetadataDateTime {
             return false;
         }
 
-//~         tm.year -= 1900;
-//~         tm.month--;
-//~         tm.isdst = -1;
-
-        var date_time = new DateTime.local (year, month, day, hour, minute, (double)second);
-//~         timestamp = tm.mktime ();
+        var date_time = new DateTime.local (year, month, day, hour, minute, (double) second);
         timestamp = date_time.to_unix ();
 
         return true;

--- a/src/MediaMetadata.vala
+++ b/src/MediaMetadata.vala
@@ -58,9 +58,10 @@ public errordomain MetadataDateTimeError {
 }
 
 public class MetadataDateTime {
-    private time_t timestamp;
+//~     private int64 timestamp;
+    private int64 timestamp;
 
-    public MetadataDateTime (time_t timestamp) {
+    public MetadataDateTime (int64 timestamp) {
         this.timestamp = timestamp;
     }
 
@@ -70,54 +71,67 @@ public class MetadataDateTime {
     }
 
     public MetadataDateTime.from_xmp (string label) throws MetadataDateTimeError {
-        TimeVal time_val = TimeVal ();
-        if (!time_val.from_iso8601 (label))
+//~         TimeVal time_val = TimeVal ();
+        DateTime? date_time = new DateTime.from_iso8601 (label, null);
+        if (date_time == null)
             throw new MetadataDateTimeError.INVALID_FORMAT ("%s is not XMP format date/time", label);
 
-        timestamp = time_val.tv_sec;
+//~         timestamp = time_val.tv_sec;
+        timestamp = date_time.to_unix ();
     }
 
-    public time_t get_timestamp () {
+    public int64 get_timestamp () {
         return timestamp;
     }
 
     public string get_exif_label () {
-        return Time.local (timestamp).format ("%Y:%m:%d %H:%M:%S");
+//~         return Time.local (timestamp).format ("%Y:%m:%d %H:%M:%S");
+        return (new DateTime.from_unix_utc (timestamp)).format ("%Y:%m:%d %H:%M:%S");
     }
 
     public string get_xmp_label () {
-        TimeVal time_val = TimeVal ();
-        time_val.tv_sec = timestamp;
-        time_val.tv_usec = 0;
-
-        return time_val.to_iso8601 ();
+//~         TimeVal time_val = TimeVal ();
+//~         time_val.tv_sec = timestamp;
+//~         time_val.tv_usec = 0;
+        var date_time = new DateTime.from_unix_utc (timestamp);
+//~         return time_val.to_iso8601 ();
+        return date_time.format_iso8601 ();
     }
 
-    private static bool from_exif_date_time (string date_time, out time_t timestamp) {
+    private static bool from_exif_date_time (string date_time_s, out int64 timestamp) {
         timestamp = 0;
 
-        Time tm = Time ();
-
         // Check standard EXIF format
-        if (date_time.scanf ("%d:%d:%d %d:%d:%d",
-                             &tm.year, &tm.month, &tm.day, &tm.hour, &tm.minute, &tm.second) != 6) {
+        int year = 0;
+        int month = 0;
+        int day =0;
+        int hour = 0;
+        int minute = 0;
+        int second = 0;
+
+        if (date_time_s.scanf ("%d:%d:%d %d:%d:%d",
+                             &year, &month, &day, &hour, &minute, &second) != 6) {
             // Fallback in a more generic format
-            string tmp = date_time.dup ();
+            string tmp = date_time_s.dup ();
             tmp.canon ("0123456789", ' ');
             if (tmp.scanf ("%4d%2d%2d%2d%2d%2d",
-                           &tm.year, &tm.month, &tm.day, &tm.hour, &tm.minute, &tm.second) != 6)
+                           year, month, day, hour, minute, second) != 6) {
                 return false;
+            }
         }
 
         // watch for bogosity
-        if (tm.year <= 1900 || tm.month <= 0 || tm.day < 0 || tm.hour < 0 || tm.minute < 0 || tm.second < 0)
+        if (year <= 0 || month <= 0 || day < 0 || hour < 0 || minute < 0 || second < 0) {
             return false;
+        }
 
-        tm.year -= 1900;
-        tm.month--;
-        tm.isdst = -1;
+//~         tm.year -= 1900;
+//~         tm.month--;
+//~         tm.isdst = -1;
 
-        timestamp = tm.mktime ();
+        var date_time = new DateTime.utc (year, month, day, hour, minute, (double)second);
+//~         timestamp = tm.mktime ();
+        timestamp = date_time.to_unix ();
 
         return true;
     }

--- a/src/MediaMetadata.vala
+++ b/src/MediaMetadata.vala
@@ -96,7 +96,7 @@ public class MetadataDateTime {
         // Check standard EXIF format
         int year = 0;
         int month = 0;
-        int day =0;
+        int day = 0;
         int hour = 0;
         int minute = 0;
         int second = 0;

--- a/src/MetadataWriter.vala
+++ b/src/MetadataWriter.vala
@@ -108,8 +108,8 @@ public class MetadataWriter : Object {
             }
 
             // exposure date/time
-            time_t current_exposure_time = photo.get_exposure_time ();
-            time_t metadata_exposure_time = 0;
+            int64 current_exposure_time = photo.get_exposure_time ();
+            int64 metadata_exposure_time = 0;
             MetadataDateTime? metadata_exposure_date_time = metadata.get_exposure_date_time ();
             if (metadata_exposure_date_time != null)
                 metadata_exposure_time = metadata_exposure_date_time.get_timestamp ();

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -145,7 +145,7 @@ public abstract class Photo : PhotoSource, Dateable {
     // Here, we cache the exposure time to avoid paying to access the row every time we
     // need to know it. This is initially set in the constructor, and updated whenever
     // the exposure time is set (please see set_exposure_time () for details).
-    private time_t cached_exposure_time;
+    private int64 cached_exposure_time;
 
     public enum Exception {
         NONE = 0,
@@ -1127,7 +1127,7 @@ public abstract class Photo : PhotoSource, Dateable {
         }
 
         Orientation orientation = Orientation.TOP_LEFT;
-        time_t exposure_time = 0;
+        int64 exposure_time = 0;
         string title = "";
         string comment = "";
 
@@ -2425,7 +2425,7 @@ public abstract class Photo : PhotoSource, Dateable {
         file_exif_updated ();
     }
 
-    public void set_exposure_time (time_t time) {
+    public void set_exposure_time (int64 time) {
         bool committed;
         lock (row) {
             committed = PhotoTable.get_instance ().set_exposure_time (row.photo_id, time);
@@ -2440,7 +2440,7 @@ public abstract class Photo : PhotoSource, Dateable {
         }
     }
 
-    public void set_exposure_time_persistent (time_t time) throws Error {
+    public void set_exposure_time_persistent (int64 time) throws Error {
         PhotoFileReader source = get_source_reader ();
 
         // Try to write to backing file

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -1951,7 +1951,7 @@ public abstract class Photo : PhotoSource, Dateable {
         }
     }
 
-    public override time_t get_timestamp () {
+    public override int64 get_timestamp () {
         lock (row) {
             return backing_photo_row.timestamp;
         }
@@ -2287,7 +2287,7 @@ public abstract class Photo : PhotoSource, Dateable {
         }
     }
 
-    public override time_t get_exposure_time () {
+    public override int64 get_exposure_time () {
         return cached_exposure_time;
     }
 

--- a/src/Thumbnail.vala
+++ b/src/Thumbnail.vala
@@ -202,8 +202,8 @@ public class Thumbnail : CheckerboardItem {
     }
 
     public static int64 exposure_time_ascending_comparator (void *a, void *b) {
-        int64 time_a = (int64) (((Thumbnail *) a)->media.get_exposure_time ());
-        int64 time_b = (int64) (((Thumbnail *) b)->media.get_exposure_time ());
+        int64 time_a = ((Thumbnail *) a)->media.get_exposure_time ();
+        int64 time_b = ((Thumbnail *) b)->media.get_exposure_time ();
         int64 result = (time_a - time_b);
 
         return (result != 0) ? result : filename_ascending_comparator (a, b);

--- a/src/TimedQueue.vala
+++ b/src/TimedQueue.vala
@@ -34,15 +34,15 @@ public delegate void DequeuedCallback<G> (G item);
 public class TimedQueue<G> {
     private class Element<G> {
         public G item;
-        public ulong ready;
+        public int64 ready;
 
-        public Element (G item, ulong ready) {
+        public Element (G item, int64 ready) {
             this.item = item;
             this.ready = ready;
         }
 
         public static int64 comparator (void *a, void *b) {
-            return (int64) ((Element *) a)->ready - (int64) ((Element *) b)->ready;
+            return ((Element *) a)->ready - ((Element *) b)->ready;
         }
     }
 
@@ -53,7 +53,7 @@ public class TimedQueue<G> {
     private uint timer_id = 0;
     private SortedList<Element<G>> queue;
     private uint dequeue_spacing_msec = 0;
-    private ulong last_dequeue = 0;
+    private int64 last_dequeue = 0;
     private bool paused_state = false;
 
     public virtual signal void paused (bool is_paused) {
@@ -150,7 +150,7 @@ public class TimedQueue<G> {
     }
 
     public virtual bool enqueue_many (Gee.Collection<G> items) {
-        ulong ready_time = calc_ready_time ();
+        int64 ready_time = calc_ready_time ();
 
         Gee.ArrayList<Element<G>> elements = new Gee.ArrayList<Element<G>> ();
         foreach (G item in items)
@@ -179,15 +179,15 @@ public class TimedQueue<G> {
         }
     }
 
-    private ulong calc_ready_time () {
-        return now_ms () + (ulong) hold_msec;
+    private int64 calc_ready_time () {
+        return now_ms () + hold_msec;
     }
 
     private bool on_heartbeat () {
         if (paused_state)
             return true;
 
-        ulong now = 0;
+        int64 now = 0;
 
         for (;;) {
             if (queue.size == 0)

--- a/src/VideoMetadata.vala
+++ b/src/VideoMetadata.vala
@@ -76,7 +76,7 @@ private class QuickTimeMetadataLoader {
     }
 
     public MetadataDateTime? get_creation_date_time () {
-        return new MetadataDateTime ((int64) get_creation_date_time_for_quicktime ());
+        return new MetadataDateTime (get_creation_date_time_for_quicktime ());
     }
 
     public string? get_title () {
@@ -320,7 +320,7 @@ private class AVIMetadataLoader {
     }
 
     public MetadataDateTime? get_creation_date_time () {
-        return new MetadataDateTime ((int64) get_creation_date_time_for_avi ());
+        return new MetadataDateTime (get_creation_date_time_for_avi ());
     }
 
     public string? get_title () {

--- a/src/VideoMetadata.vala
+++ b/src/VideoMetadata.vala
@@ -67,7 +67,7 @@ private class QuickTimeMetadataLoader {
 
     // Quicktime calendar date/time format is number of seconds since January 1, 1904.
     // This converts to UNIX time (66 years + 17 leap days).
-    public const time_t QUICKTIME_EPOCH_ADJUSTMENT = 2082844800;
+    public const int64 QUICKTIME_EPOCH_ADJUSTMENT = 2082844800;
 
     private File file = null;
 
@@ -76,7 +76,7 @@ private class QuickTimeMetadataLoader {
     }
 
     public MetadataDateTime? get_creation_date_time () {
-        return new MetadataDateTime ((time_t) get_creation_date_time_for_quicktime ());
+        return new MetadataDateTime ((int64) get_creation_date_time_for_quicktime ());
     }
 
     public string? get_title () {
@@ -124,9 +124,9 @@ private class QuickTimeMetadataLoader {
         return ret;
     }
 
-    private ulong get_creation_date_time_for_quicktime () {
+    private int64 get_creation_date_time_for_quicktime () {
         QuickTimeAtom test = new QuickTimeAtom (file);
-        time_t timestamp = 0;
+        int64 timestamp = 0;
 
         try {
             test.open_file ();
@@ -179,7 +179,7 @@ private class QuickTimeMetadataLoader {
         if (timestamp < 0)
             timestamp += QUICKTIME_EPOCH_ADJUSTMENT;
 
-        return (ulong) timestamp;
+        return timestamp;
     }
 }
 
@@ -320,7 +320,7 @@ private class AVIMetadataLoader {
     }
 
     public MetadataDateTime? get_creation_date_time () {
-        return new MetadataDateTime ((time_t) get_creation_date_time_for_avi ());
+        return new MetadataDateTime ((int64) get_creation_date_time_for_avi ());
     }
 
     public string? get_title () {
@@ -442,7 +442,7 @@ private class AVIMetadataLoader {
     // Largely based on GStreamer's avi/gstavidemux.c
     // and the information here:
     // http://www.eden-foundation.org/products/code/film_date_stamp/index.html
-    private ulong parse_date (string sdate) {
+    private int64 parse_date (string sdate) {
         if (sdate.length == 0) {
             return 0;
         }
@@ -480,8 +480,8 @@ private class AVIMetadataLoader {
         date.to_time (out time);
 
         // watch for overflow (happens on quasi-bogus dates, like Year 200)
-        time_t tm = time.mktime ();
-        ulong result = tm + seconds;
+        int64 tm = time.mktime ();
+        int64 result = tm + seconds;
         if (result < tm) {
             debug ("Overflow for timestamp in video file %s", file.get_path ());
 
@@ -521,9 +521,9 @@ private class AVIMetadataLoader {
         return DateMonth.BAD_MONTH;
     }
 
-    private ulong get_creation_date_time_for_avi () {
+    private int64 get_creation_date_time_for_avi () {
         AVIChunk chunk = new AVIChunk (file);
-        ulong timestamp = 0;
+        int64 timestamp = 0;
         try {
             chunk.open_file ();
             chunk.nonsection_skip (12); // Advance past 12 byte header.
@@ -540,6 +540,7 @@ private class AVIMetadataLoader {
         } catch (GLib.Error e) {
             debug ("Error while closing AVI file: %s", e.message);
         }
+
         return timestamp;
     }
 }

--- a/src/VideoSupport.vala
+++ b/src/VideoSupport.vala
@@ -164,8 +164,7 @@ public class VideoReader {
 
         if (exposure_time == 0) {
             // Use time reported by Gstreamer, if available.
-            exposure_time = (int64) (reader.timestamp != null ?
-                                      reader.timestamp.to_unix () : 0);
+            exposure_time = (reader.timestamp != null ? reader.timestamp.to_unix () : 0);
         }
 
         params.row.video_id = VideoID ();

--- a/src/VideoSupport.vala
+++ b/src/VideoSupport.vala
@@ -30,7 +30,8 @@ public class VideoImportParams {
     public File file;
     public ImportID import_id = ImportID ();
     public string? md5;
-    public time_t exposure_time_override;
+//~     public int64 exposure_time_override;
+    public int64 exposure_time_override;
 
     // IN/OUT:
     public Thumbnails? thumbnails;
@@ -39,7 +40,7 @@ public class VideoImportParams {
     public VideoRow row = new VideoRow ();
 
     public VideoImportParams (File file, ImportID import_id, string? md5,
-                              Thumbnails? thumbnails = null, time_t exposure_time_override = 0) {
+                              Thumbnails? thumbnails = null, int64 exposure_time_override = 0) {
         this.file = file;
         this.import_id = import_id;
         this.md5 = md5;
@@ -124,7 +125,7 @@ public class VideoReader {
         // make sure params has a valid md5
         assert (params.md5 != null);
 
-        time_t exposure_time = params.exposure_time_override;
+        int64 exposure_time = params.exposure_time_override;
         string title = "";
         string comment = "";
 
@@ -164,7 +165,7 @@ public class VideoReader {
 
         if (exposure_time == 0) {
             // Use time reported by Gstreamer, if available.
-            exposure_time = (time_t) (reader.timestamp != null ?
+            exposure_time = (int64) (reader.timestamp != null ?
                                       reader.timestamp.to_unix () : 0);
         }
 
@@ -740,13 +741,13 @@ public class Video : VideoSource, Flaggable, Monitorable, Dateable {
         }
     }
 
-    public override time_t get_exposure_time () {
+    public override int64 get_exposure_time () {
         lock (backing_row) {
             return backing_row.exposure_time;
         }
     }
 
-    public void set_exposure_time (time_t time) {
+    public void set_exposure_time (int64 time) {
         lock (backing_row) {
             try {
                 VideoTable.get_instance ().set_exposure_time (backing_row.video_id, time);
@@ -779,7 +780,7 @@ public class Video : VideoSource, Flaggable, Monitorable, Dateable {
         }
     }
 
-    public override time_t get_timestamp () {
+    public override int64 get_timestamp () {
         lock (backing_row) {
             return backing_row.timestamp;
         }

--- a/src/VideoSupport.vala
+++ b/src/VideoSupport.vala
@@ -30,7 +30,6 @@ public class VideoImportParams {
     public File file;
     public ImportID import_id = ImportID ();
     public string? md5;
-//~     public int64 exposure_time_override;
     public int64 exposure_time_override;
 
     // IN/OUT:

--- a/src/Views/EventsDirectoryPage.vala
+++ b/src/Views/EventsDirectoryPage.vala
@@ -192,8 +192,8 @@ public abstract class EventsDirectoryPage : CheckerboardPage {
     }
 
     private static int64 event_ascending_comparator (void *a, void *b) {
-        time_t start_a = ((EventDirectoryItem *) a)->event.get_start_time ();
-        time_t start_b = ((EventDirectoryItem *) b)->event.get_start_time ();
+        int64 start_a = ((EventDirectoryItem *) a)->event.get_start_time ();
+        int64 start_b = ((EventDirectoryItem *) b)->event.get_start_time ();
 
         return start_a - start_b;
     }
@@ -338,13 +338,13 @@ public class SubEventsDirectoryPage : EventsDirectoryPage {
         private int year = 0;
         DirectoryType type;
 
-        public SubEventDirectoryManager (DirectoryType type, Time time) {
+        public SubEventDirectoryManager (DirectoryType type, DateTime time) {
             base ();
 
             if (type == DirectoryType.MONTH)
-                month = time.month;
+                month = time.get_month ();
             this.type = type;
-            year = time.year;
+            year = time.get_year ();
         }
 
         public override bool include_in_view (DataSource source) {
@@ -352,11 +352,12 @@ public class SubEventsDirectoryPage : EventsDirectoryPage {
                 return false;
 
             EventSource event = (EventSource) source;
-            Time event_time = Time.local (event.get_start_time ());
-            if (event_time.year == year) {
+            DateTime event_time = new DateTime.from_unix_local (event.get_start_time ());
+            if (event_time.get_year () == year) {
                 if (type == DirectoryType.MONTH) {
-                    return (event_time.month == month);
+                    return (event_time.get_month () == month);
                 }
+
                 return true;
             }
             return false;
@@ -375,7 +376,7 @@ public class SubEventsDirectoryPage : EventsDirectoryPage {
         }
     }
 
-    public SubEventsDirectoryPage (DirectoryType type, Time time) {
+    public SubEventsDirectoryPage (DirectoryType type, DateTime time) {
         string page_name;
         if (type == SubEventsDirectoryPage.DirectoryType.UNDATED) {
             page_name = UNDATED_PAGE_NAME;

--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -36,12 +36,12 @@ abstract class ImportSource : ThumbnailSource, Indexable {
     public string folder { get; construct; }
     public ulong file_size { get; construct; }
 
-    private time_t modification_time;
+    private int64 modification_time;
     private Gdk.Pixbuf? preview = null;
     private string? indexable_keywords = null;
 
     protected ImportSource (string camera_name, GPhoto.Camera camera, int fsid, string folder,
-                            string filename, ulong file_size, time_t modification_time) {
+                            string filename, ulong file_size, int64 modification_time) {
         Object (
             camera: camera,
             camera_name: camera_name,
@@ -58,7 +58,7 @@ abstract class ImportSource : ThumbnailSource, Indexable {
         this.preview = preview;
     }
 
-    public time_t get_modification_time () {
+    public int64 get_modification_time () {
         return modification_time;
     }
 
@@ -66,7 +66,7 @@ abstract class ImportSource : ThumbnailSource, Indexable {
         return preview;
     }
 
-    public virtual time_t get_exposure_time () {
+    public virtual int64 get_exposure_time () {
         return get_modification_time ();
     }
 
@@ -103,7 +103,7 @@ abstract class ImportSource : ThumbnailSource, Indexable {
 
 class VideoImportSource : ImportSource {
     public VideoImportSource (string camera_name, GPhoto.Camera camera, int fsid, string folder,
-                              string filename, ulong file_size, time_t modification_time) {
+                              string filename, ulong file_size, int64 modification_time) {
         base (camera_name, camera, fsid, folder, filename, file_size, modification_time);
     }
 
@@ -152,7 +152,7 @@ class PhotoImportSource : ImportSource {
     private PhotoImportSource? associated = null; // JPEG source for RAW+JPEG
 
     public PhotoImportSource (string camera_name, GPhoto.Camera camera, int fsid, string folder,
-                              string filename, ulong file_size, time_t modification_time, PhotoFileFormat file_format) {
+                              string filename, ulong file_size, int64 modification_time, PhotoFileFormat file_format) {
         base (camera_name, camera, fsid, folder, filename, file_size, modification_time);
         this.file_format = file_format;
     }
@@ -193,7 +193,7 @@ class PhotoImportSource : ImportSource {
         this.exif_md5 = exif_md5;
     }
 
-    public override time_t get_exposure_time () {
+    public override int64 get_exposure_time () {
         if (metadata == null)
             return get_modification_time ();
 
@@ -483,7 +483,7 @@ public class ImportPage : CheckerboardPage {
         private string filename;
         private uint64 filesize;
         private PhotoMetadata metadata;
-        private time_t exposure_time;
+        private int64 exposure_time;
         private CameraImportJob? associated = null;
         private BackingPhotoRow? associated_file = null;
         private DuplicatedFile? duplicated_file;
@@ -509,7 +509,7 @@ public class ImportPage : CheckerboardPage {
             exposure_time = import_file.get_exposure_time ();
         }
 
-        public time_t get_exposure_time () {
+        public int64 get_exposure_time () {
             return exposure_time;
         }
 
@@ -517,7 +517,7 @@ public class ImportPage : CheckerboardPage {
             return duplicated_file;
         }
 
-        public override time_t get_exposure_time_override () {
+        public override int64 get_exposure_time_override () {
             return (import_file is VideoImportSource) ? get_exposure_time () : 0;
         }
 

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -27,7 +27,7 @@ public abstract class Page : Gtk.ScrolledWindow {
     private Gtk.Window container = null;
     private Gdk.Rectangle last_position = Gdk.Rectangle ();
     private Gtk.Widget event_source = null;
-    private ulong last_configure_ms = 0;
+    private int64 last_configure_ms = 0;
     private bool report_move_finished = false;
     private bool report_resize_finished = false;
     private Gdk.Point last_down = Gdk.Point ();

--- a/src/core/DataSourceTypes.vala
+++ b/src/core/DataSourceTypes.vala
@@ -85,9 +85,9 @@ public abstract class EventSource : ThumbnailSource {
         base (object_id);
     }
 
-    public abstract time_t get_start_time ();
+    public abstract int64 get_start_time ();
 
-    public abstract time_t get_end_time ();
+    public abstract int64 get_end_time ();
 
     public abstract uint64 get_total_filesize ();
 

--- a/src/db/EventTable.vala
+++ b/src/db/EventTable.vala
@@ -145,7 +145,7 @@ public class EventTable : DatabaseTable {
         if (row.name != null && row.name.length == 0)
             row.name = null;
         row.primary_source_id = source_id_upgrade (stmt.column_int64 (1), stmt.column_text (2));
-        row.time_created = (int64) stmt.column_int64 (3);
+        row.time_created = stmt.column_int64 (3);
         row.comment = stmt.column_text (4);
 
         return row;
@@ -174,7 +174,7 @@ public class EventTable : DatabaseTable {
             row.event_id = EventID (stmt.column_int64 (0));
             row.name = stmt.column_text (1);
             row.primary_source_id = source_id_upgrade (stmt.column_int64 (2), stmt.column_text (3));
-            row.time_created = (int64) stmt.column_int64 (4);
+            row.time_created = stmt.column_int64 (4);
             row.comment = stmt.column_text (5);
 
             event_rows.add (row);
@@ -214,7 +214,7 @@ public class EventTable : DatabaseTable {
         if (!select_by_id (event_id.id, "time_created", out stmt))
             return 0;
 
-        return (int64) stmt.column_int64 (0);
+        return stmt.column_int64 (0);
     }
 
     public bool set_comment (EventID event_id, string new_comment) {

--- a/src/db/EventTable.vala
+++ b/src/db/EventTable.vala
@@ -38,7 +38,7 @@ public struct EventID {
 public class EventRow {
     public EventID event_id;
     public string? name;
-    public time_t time_created;
+    public int64 time_created;
     public string? primary_source_id;
     public string? comment;
 }
@@ -88,7 +88,7 @@ public class EventTable : DatabaseTable {
 
         var stmt = create_stmt ("INSERT INTO EventTable (primary_source_id, time_created, comment) VALUES (?, ?, ?)");
 
-        time_t time_created = (time_t) now_sec ();
+        int64 time_created = (int64) now_sec ();
 
         bind_text (stmt, 1, primary_source_id);
         bind_int64 (stmt, 2, time_created);
@@ -145,7 +145,7 @@ public class EventTable : DatabaseTable {
         if (row.name != null && row.name.length == 0)
             row.name = null;
         row.primary_source_id = source_id_upgrade (stmt.column_int64 (1), stmt.column_text (2));
-        row.time_created = (time_t) stmt.column_int64 (3);
+        row.time_created = (int64) stmt.column_int64 (3);
         row.comment = stmt.column_text (4);
 
         return row;
@@ -174,7 +174,7 @@ public class EventTable : DatabaseTable {
             row.event_id = EventID (stmt.column_int64 (0));
             row.name = stmt.column_text (1);
             row.primary_source_id = source_id_upgrade (stmt.column_int64 (2), stmt.column_text (3));
-            row.time_created = (time_t) stmt.column_int64 (4);
+            row.time_created = (int64) stmt.column_int64 (4);
             row.comment = stmt.column_text (5);
 
             event_rows.add (row);
@@ -209,12 +209,12 @@ public class EventTable : DatabaseTable {
         return update_text_by_id (event_id.id, "primary_source_id", primary_source_id);
     }
 
-    public time_t get_time_created (EventID event_id) {
+    public int64 get_time_created (EventID event_id) {
         Sqlite.Statement stmt;
         if (!select_by_id (event_id.id, "time_created", out stmt))
             return 0;
 
-        return (time_t) stmt.column_int64 (0);
+        return (int64) stmt.column_int64 (0);
     }
 
     public bool set_comment (EventID event_id, string new_comment) {

--- a/src/db/EventTable.vala
+++ b/src/db/EventTable.vala
@@ -88,7 +88,7 @@ public class EventTable : DatabaseTable {
 
         var stmt = create_stmt ("INSERT INTO EventTable (primary_source_id, time_created, comment) VALUES (?, ?, ?)");
 
-        int64 time_created = (int64) now_sec ();
+        int64 time_created = now_sec ();
 
         bind_text (stmt, 1, primary_source_id);
         bind_int64 (stmt, 2, time_created);

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -85,7 +85,7 @@ public struct ImportID {
 public class PhotoRow {
     public PhotoID photo_id;
     public BackingPhotoRow master;
-    public time_t exposure_time;
+    public int64 exposure_time;
     public ImportID import_id;
     public EventID event_id;
     public Orientation orientation;
@@ -93,12 +93,12 @@ public class PhotoRow {
     public string md5;
     public string? thumbnail_md5;
     public string? exif_md5;
-    public time_t time_created;
+    public int64 time_created;
     public uint64 flags;
     public string? title;
     public string? comment;
     public string? backlinks;
-    public time_t time_reimported;
+    public int64 time_reimported;
     public BackingPhotoID editable_id;
     public bool metadata_dirty;
     public bool enhanced;
@@ -222,7 +222,7 @@ public class PhotoTable : DatabaseTable {
         photo_row.photo_id = PhotoID (db.last_insert_rowid ());
         photo_row.orientation = photo_row.master.original_orientation;
         photo_row.event_id = EventID ();
-        photo_row.time_created = (time_t) time_created;
+        photo_row.time_created = (int64) time_created;
         photo_row.flags = 0;
 
         return photo_row.photo_id;
@@ -240,7 +240,7 @@ public class PhotoTable : DatabaseTable {
             + "exif_md5 = ?, thumbnail_md5 = ?, file_format = ?, title = ?, time_reimported = ? "
             + "WHERE id = ?");
 
-        time_t time_reimported = (time_t) now_sec ();
+        int64 time_reimported = (int64) now_sec ();
 
         bind_int (stmt, 1, row.master.dim.width);
         bind_int (stmt, 2, row.master.dim.height);
@@ -332,8 +332,8 @@ public class PhotoTable : DatabaseTable {
         row.master.filepath = stmt.column_text (0);
         row.master.dim = Dimensions (stmt.column_int (1), stmt.column_int (2));
         row.master.filesize = stmt.column_int64 (3);
-        row.master.timestamp = (time_t) stmt.column_int64 (4);
-        row.exposure_time = (time_t) stmt.column_int64 (5);
+        row.master.timestamp = (int64) stmt.column_int64 (4);
+        row.exposure_time = (int64) stmt.column_int64 (5);
         row.orientation = (Orientation) stmt.column_int (6);
         row.master.original_orientation = (Orientation) stmt.column_int (7);
         row.import_id.id = stmt.column_int64 (8);
@@ -342,12 +342,12 @@ public class PhotoTable : DatabaseTable {
         row.md5 = stmt.column_text (11);
         row.thumbnail_md5 = stmt.column_text (12);
         row.exif_md5 = stmt.column_text (13);
-        row.time_created = (time_t) stmt.column_int64 (14);
+        row.time_created = (int64) stmt.column_int64 (14);
         row.flags = stmt.column_int64 (15);
         row.master.file_format = PhotoFileFormat.unserialize (stmt.column_int (16));
         row.title = stmt.column_text (17);
         row.backlinks = stmt.column_text (18);
-        row.time_reimported = (time_t) stmt.column_int64 (19);
+        row.time_reimported = (int64) stmt.column_int64 (19);
         row.editable_id = BackingPhotoID (stmt.column_int64 (20));
         row.metadata_dirty = stmt.column_int (21) != 0;
         row.developer = stmt.column_text (22) != null ? RawDeveloper.from_string (stmt.column_text (22)) :
@@ -378,8 +378,8 @@ public class PhotoTable : DatabaseTable {
             row.master.filepath = stmt.column_text (1);
             row.master.dim = Dimensions (stmt.column_int (2), stmt.column_int (3));
             row.master.filesize = stmt.column_int64 (4);
-            row.master.timestamp = (time_t) stmt.column_int64 (5);
-            row.exposure_time = (time_t) stmt.column_int64 (6);
+            row.master.timestamp = (int64) stmt.column_int64 (5);
+            row.exposure_time = (int64) stmt.column_int64 (6);
             row.orientation = (Orientation) stmt.column_int (7);
             row.master.original_orientation = (Orientation) stmt.column_int (8);
             row.import_id.id = stmt.column_int64 (9);
@@ -388,12 +388,12 @@ public class PhotoTable : DatabaseTable {
             row.md5 = stmt.column_text (12);
             row.thumbnail_md5 = stmt.column_text (13);
             row.exif_md5 = stmt.column_text (14);
-            row.time_created = (time_t) stmt.column_int64 (15);
+            row.time_created = (int64) stmt.column_int64 (15);
             row.flags = stmt.column_int64 (16);
             row.master.file_format = PhotoFileFormat.unserialize (stmt.column_int (17));
             row.title = stmt.column_text (18);
             row.backlinks = stmt.column_text (19);
-            row.time_reimported = (time_t) stmt.column_int64 (20);
+            row.time_reimported = (int64) stmt.column_int64 (20);
             row.editable_id = BackingPhotoID (stmt.column_int64 (21));
             row.metadata_dirty = stmt.column_int (22) != 0;
             row.developer = stmt.column_text (23) != null ? RawDeveloper.from_string (stmt.column_text (23)) :
@@ -479,11 +479,11 @@ public class PhotoTable : DatabaseTable {
         update_text_by_id_2 (photo_id.id, "filename", filepath);
     }
 
-    public void update_timestamp (PhotoID photo_id, time_t timestamp) throws DatabaseError {
+    public void update_timestamp (PhotoID photo_id, int64 timestamp) throws DatabaseError {
         update_int64_by_id_2 (photo_id.id, "timestamp", timestamp);
     }
 
-    public bool set_exposure_time (PhotoID photo_id, time_t time) {
+    public bool set_exposure_time (PhotoID photo_id, int64 time) {
         return update_int64_by_id (photo_id.id, "exposure_time", (int64) time);
     }
 
@@ -976,10 +976,10 @@ public struct BackingPhotoID {
 
 public class BackingPhotoRow {
     public BackingPhotoID id;
-    public time_t time_created;
+    public int64 time_created;
     public string? filepath = null;
     public int64 filesize;
-    public time_t timestamp;
+    public int64 timestamp;
     public PhotoFileFormat file_format;
     public Dimensions dim;
     public Orientation original_orientation;
@@ -1050,7 +1050,7 @@ public class BackingPhotoTable : DatabaseTable {
             + "file_format, time_created) "
             + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
 
-        time_t time_created = (time_t) now_sec ();
+        int64 time_created = (int64) now_sec ();
 
         bind_text (stmt, 1, state.filepath);
         bind_int64 (stmt, 2, state.timestamp);
@@ -1084,12 +1084,12 @@ public class BackingPhotoTable : DatabaseTable {
         BackingPhotoRow row = new BackingPhotoRow ();
         row.id = id;
         row.filepath = stmt.column_text (0);
-        row.timestamp = (time_t) stmt.column_int64 (1);
+        row.timestamp = (int64) stmt.column_int64 (1);
         row.filesize = stmt.column_int64 (2);
         row.dim = Dimensions (stmt.column_int (3), stmt.column_int (4));
         row.original_orientation = (Orientation) stmt.column_int (5);
         row.file_format = PhotoFileFormat.unserialize (stmt.column_int (6));
-        row.time_created = (time_t) stmt.column_int64 (7);
+        row.time_created = (int64) stmt.column_int64 (7);
 
         return row;
     }
@@ -1114,7 +1114,7 @@ public class BackingPhotoTable : DatabaseTable {
             throw_error ("BackingPhotoTable.update", res);
     }
 
-    public void update_attributes (BackingPhotoID id, time_t timestamp, int64 filesize) throws DatabaseError {
+    public void update_attributes (BackingPhotoID id, int64 timestamp, int64 filesize) throws DatabaseError {
         var stmt = create_stmt ("UPDATE BackingPhotoTable SET timestamp=?, filesize=? WHERE id=?");
 
         bind_int64 (stmt, 1, timestamp);
@@ -1134,7 +1134,7 @@ public class BackingPhotoTable : DatabaseTable {
         update_text_by_id_2 (id.id, "filepath", filepath);
     }
 
-    public void update_timestamp (BackingPhotoID id, time_t timestamp) throws DatabaseError {
+    public void update_timestamp (BackingPhotoID id, int64 timestamp) throws DatabaseError {
         update_int64_by_id_2 (id.id, "timestamp", timestamp);
     }
 }

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -222,7 +222,7 @@ public class PhotoTable : DatabaseTable {
         photo_row.photo_id = PhotoID (db.last_insert_rowid ());
         photo_row.orientation = photo_row.master.original_orientation;
         photo_row.event_id = EventID ();
-        photo_row.time_created = (int64) time_created;
+        photo_row.time_created = time_created;
         photo_row.flags = 0;
 
         return photo_row.photo_id;
@@ -332,8 +332,8 @@ public class PhotoTable : DatabaseTable {
         row.master.filepath = stmt.column_text (0);
         row.master.dim = Dimensions (stmt.column_int (1), stmt.column_int (2));
         row.master.filesize = stmt.column_int64 (3);
-        row.master.timestamp = (int64) stmt.column_int64 (4);
-        row.exposure_time = (int64) stmt.column_int64 (5);
+        row.master.timestamp = stmt.column_int64 (4);
+        row.exposure_time = stmt.column_int64 (5);
         row.orientation = (Orientation) stmt.column_int (6);
         row.master.original_orientation = (Orientation) stmt.column_int (7);
         row.import_id.id = stmt.column_int64 (8);
@@ -342,12 +342,12 @@ public class PhotoTable : DatabaseTable {
         row.md5 = stmt.column_text (11);
         row.thumbnail_md5 = stmt.column_text (12);
         row.exif_md5 = stmt.column_text (13);
-        row.time_created = (int64) stmt.column_int64 (14);
+        row.time_created = stmt.column_int64 (14);
         row.flags = stmt.column_int64 (15);
         row.master.file_format = PhotoFileFormat.unserialize (stmt.column_int (16));
         row.title = stmt.column_text (17);
         row.backlinks = stmt.column_text (18);
-        row.time_reimported = (int64) stmt.column_int64 (19);
+        row.time_reimported = stmt.column_int64 (19);
         row.editable_id = BackingPhotoID (stmt.column_int64 (20));
         row.metadata_dirty = stmt.column_int (21) != 0;
         row.developer = stmt.column_text (22) != null ? RawDeveloper.from_string (stmt.column_text (22)) :
@@ -378,8 +378,8 @@ public class PhotoTable : DatabaseTable {
             row.master.filepath = stmt.column_text (1);
             row.master.dim = Dimensions (stmt.column_int (2), stmt.column_int (3));
             row.master.filesize = stmt.column_int64 (4);
-            row.master.timestamp = (int64) stmt.column_int64 (5);
-            row.exposure_time = (int64) stmt.column_int64 (6);
+            row.master.timestamp = stmt.column_int64 (5);
+            row.exposure_time = stmt.column_int64 (6);
             row.orientation = (Orientation) stmt.column_int (7);
             row.master.original_orientation = (Orientation) stmt.column_int (8);
             row.import_id.id = stmt.column_int64 (9);
@@ -388,12 +388,12 @@ public class PhotoTable : DatabaseTable {
             row.md5 = stmt.column_text (12);
             row.thumbnail_md5 = stmt.column_text (13);
             row.exif_md5 = stmt.column_text (14);
-            row.time_created = (int64) stmt.column_int64 (15);
+            row.time_created = stmt.column_int64 (15);
             row.flags = stmt.column_int64 (16);
             row.master.file_format = PhotoFileFormat.unserialize (stmt.column_int (17));
             row.title = stmt.column_text (18);
             row.backlinks = stmt.column_text (19);
-            row.time_reimported = (int64) stmt.column_int64 (20);
+            row.time_reimported = stmt.column_int64 (20);
             row.editable_id = BackingPhotoID (stmt.column_int64 (21));
             row.metadata_dirty = stmt.column_int (22) != 0;
             row.developer = stmt.column_text (23) != null ? RawDeveloper.from_string (stmt.column_text (23)) :
@@ -484,7 +484,7 @@ public class PhotoTable : DatabaseTable {
     }
 
     public bool set_exposure_time (PhotoID photo_id, int64 time) {
-        return update_int64_by_id (photo_id.id, "exposure_time", (int64) time);
+        return update_int64_by_id (photo_id.id, "exposure_time", time);
     }
 
     public void set_import_id (PhotoID photo_id, ImportID import_id) throws DatabaseError {
@@ -1059,7 +1059,7 @@ public class BackingPhotoTable : DatabaseTable {
         bind_int (stmt, 5, state.dim.height);
         bind_int (stmt, 6, state.original_orientation);
         bind_int (stmt, 7, state.file_format.serialize ());
-        bind_int64 (stmt, 8, (int64) time_created);
+        bind_int64 (stmt, 8, time_created);
 
         var res = stmt.step ();
         if (res != Sqlite.DONE)
@@ -1084,12 +1084,12 @@ public class BackingPhotoTable : DatabaseTable {
         BackingPhotoRow row = new BackingPhotoRow ();
         row.id = id;
         row.filepath = stmt.column_text (0);
-        row.timestamp = (int64) stmt.column_int64 (1);
+        row.timestamp = stmt.column_int64 (1);
         row.filesize = stmt.column_int64 (2);
         row.dim = Dimensions (stmt.column_int (3), stmt.column_int (4));
         row.original_orientation = (Orientation) stmt.column_int (5);
         row.file_format = PhotoFileFormat.unserialize (stmt.column_int (6));
-        row.time_created = (int64) stmt.column_int64 (7);
+        row.time_created = stmt.column_int64 (7);
 
         return row;
     }

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -265,7 +265,7 @@ public class PhotoTable : DatabaseTable {
         row.orientation = row.master.original_orientation;
     }
 
-    public bool master_exif_updated (PhotoID photo_id, int64 filesize, long timestamp,
+    public bool master_exif_updated (PhotoID photo_id, int64 filesize, int64 timestamp,
                                      string md5, string? exif_md5, string? thumbnail_md5, PhotoRow row) {
         var stmt = create_stmt (
             "UPDATE PhotoTable SET filesize = ?, timestamp = ?, md5 = ?, exif_md5 = ?,"

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -57,11 +57,7 @@ public struct ImportID {
     }
 
     public static ImportID generate () {
-        TimeVal timestamp = TimeVal ();
-        timestamp.get_current_time ();
-        int64 id = timestamp.tv_sec;
-
-        return ImportID (id);
+        return ImportID (now_sec ());
     }
 
     public bool is_invalid () {

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -188,7 +188,7 @@ public class PhotoTable : DatabaseTable {
             + "exif_md5, time_created, file_format, title, editable_id, developer, comment) "
             + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
-        ulong time_created = now_sec ();
+        int64 time_created = now_sec ();
 
         bind_text (stmt, 1, photo_row.master.filepath);
         bind_int (stmt, 2, photo_row.master.dim.width);

--- a/src/db/PhotoTable.vala
+++ b/src/db/PhotoTable.vala
@@ -236,7 +236,7 @@ public class PhotoTable : DatabaseTable {
             + "exif_md5 = ?, thumbnail_md5 = ?, file_format = ?, title = ?, time_reimported = ? "
             + "WHERE id = ?");
 
-        int64 time_reimported = (int64) now_sec ();
+        int64 time_reimported = now_sec ();
 
         bind_int (stmt, 1, row.master.dim.width);
         bind_int (stmt, 2, row.master.dim.height);
@@ -1046,7 +1046,7 @@ public class BackingPhotoTable : DatabaseTable {
             + "file_format, time_created) "
             + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
 
-        int64 time_created = (int64) now_sec ();
+        int64 time_created = now_sec ();
 
         bind_text (stmt, 1, state.filepath);
         bind_int64 (stmt, 2, state.timestamp);

--- a/src/db/TagTable.vala
+++ b/src/db/TagTable.vala
@@ -39,7 +39,7 @@ public class TagRow {
     public TagID tag_id;
     public string name;
     public Gee.Set<string>? source_id_list;
-    public time_t time_created;
+    public int64 time_created;
 }
 
 public class TagTable : DatabaseTable {
@@ -87,7 +87,7 @@ public class TagTable : DatabaseTable {
     public TagRow add (string name) throws DatabaseError {
         var stmt = create_stmt ("INSERT INTO TagTable (name, time_created) VALUES (?, ?)");
 
-        time_t time_created = (time_t) now_sec ();
+        int64 time_created = (int64) now_sec ();
 
         bind_text (stmt, 1, name);
         bind_int64 (stmt, 2, time_created);
@@ -147,7 +147,7 @@ public class TagTable : DatabaseTable {
         row.tag_id = tag_id;
         row.name = stmt.column_text (0);
         row.source_id_list = unserialize_source_ids (stmt.column_text (1));
-        row.time_created = (time_t) stmt.column_int64 (2);
+        row.time_created = (int64) stmt.column_int64 (2);
 
         return row;
     }
@@ -169,7 +169,7 @@ public class TagTable : DatabaseTable {
             row.tag_id = TagID (stmt.column_int64 (0));
             row.name = stmt.column_text (1);
             row.source_id_list = unserialize_source_ids (stmt.column_text (2));
-            row.time_created = (time_t) stmt.column_int64 (3);
+            row.time_created = (int64) stmt.column_int64 (3);
 
             rows.add (row);
         }

--- a/src/db/TagTable.vala
+++ b/src/db/TagTable.vala
@@ -87,7 +87,7 @@ public class TagTable : DatabaseTable {
     public TagRow add (string name) throws DatabaseError {
         var stmt = create_stmt ("INSERT INTO TagTable (name, time_created) VALUES (?, ?)");
 
-        int64 time_created = (int64) now_sec ();
+        int64 time_created = now_sec ();
 
         bind_text (stmt, 1, name);
         bind_int64 (stmt, 2, time_created);

--- a/src/db/TagTable.vala
+++ b/src/db/TagTable.vala
@@ -147,7 +147,7 @@ public class TagTable : DatabaseTable {
         row.tag_id = tag_id;
         row.name = stmt.column_text (0);
         row.source_id_list = unserialize_source_ids (stmt.column_text (1));
-        row.time_created = (int64) stmt.column_int64 (2);
+        row.time_created = stmt.column_int64 (2);
 
         return row;
     }
@@ -169,7 +169,7 @@ public class TagTable : DatabaseTable {
             row.tag_id = TagID (stmt.column_int64 (0));
             row.name = stmt.column_text (1);
             row.source_id_list = unserialize_source_ids (stmt.column_text (2));
-            row.time_created = (int64) stmt.column_int64 (3);
+            row.time_created = stmt.column_int64 (3);
 
             rows.add (row);
         }

--- a/src/db/TombstoneTable.vala
+++ b/src/db/TombstoneTable.vala
@@ -80,7 +80,7 @@ public class TombstoneTable : DatabaseTable {
         + "(filepath, filesize, md5, time_created, reason) "
         + "VALUES (?, ?, ?, ?, ?)");
 
-        int64 time_created = (int64) now_sec ();
+        int64 time_created = now_sec ();
 
         bind_text (stmt, 1, filepath);
         bind_int64 (stmt, 2, filesize);

--- a/src/db/TombstoneTable.vala
+++ b/src/db/TombstoneTable.vala
@@ -40,7 +40,7 @@ public class TombstoneRow {
     public string filepath;
     public int64 filesize;
     public string? md5;
-    public time_t time_created;
+    public int64 time_created;
     public Tombstone.Reason reason;
 }
 
@@ -80,7 +80,7 @@ public class TombstoneTable : DatabaseTable {
         + "(filepath, filesize, md5, time_created, reason) "
         + "VALUES (?, ?, ?, ?, ?)");
 
-        time_t time_created = (time_t) now_sec ();
+        int64 time_created = (int64) now_sec ();
 
         bind_text (stmt, 1, filepath);
         bind_int64 (stmt, 2, filesize);
@@ -126,7 +126,7 @@ public class TombstoneTable : DatabaseTable {
             row.filepath = stmt.column_text (1);
             row.filesize = stmt.column_int64 (2);
             row.md5 = stmt.column_text (3);
-            row.time_created = (time_t) stmt.column_int64 (4);
+            row.time_created = (int64) stmt.column_int64 (4);
             row.reason = Tombstone.Reason.unserialize (stmt.column_int (5));
 
             rows[index++] = row;

--- a/src/db/TombstoneTable.vala
+++ b/src/db/TombstoneTable.vala
@@ -85,7 +85,7 @@ public class TombstoneTable : DatabaseTable {
         bind_text (stmt, 1, filepath);
         bind_int64 (stmt, 2, filesize);
         bind_text (stmt, 3, md5);
-        bind_int64 (stmt, 4, (int64) time_created);
+        bind_int64 (stmt, 4, time_created);
         bind_int (stmt, 5, reason.serialize ());
 
         var res = stmt.step ();
@@ -126,7 +126,7 @@ public class TombstoneTable : DatabaseTable {
             row.filepath = stmt.column_text (1);
             row.filesize = stmt.column_int64 (2);
             row.md5 = stmt.column_text (3);
-            row.time_created = (int64) stmt.column_int64 (4);
+            row.time_created = stmt.column_int64 (4);
             row.reason = Tombstone.Reason.unserialize (stmt.column_int (5));
 
             rows[index++] = row;

--- a/src/db/VideoTable.vala
+++ b/src/db/VideoTable.vala
@@ -121,7 +121,7 @@ public class VideoTable : DatabaseTable {
             + "filesize, timestamp, exposure_time, import_id, event_id, md5, time_created, title, comment) "
             + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
-        ulong time_created = now_sec ();
+        int64 time_created = now_sec ();
 
         bind_text (stmt, 1, video_row.filepath);
         bind_int (stmt, 2, video_row.width);

--- a/src/db/VideoTable.vala
+++ b/src/db/VideoTable.vala
@@ -147,7 +147,7 @@ public class VideoTable : DatabaseTable {
         // fill in ignored fields with database values
         video_row.video_id = VideoID (db.last_insert_rowid ());
         video_row.event_id = EventID ();
-        video_row.time_created = (int64) time_created;
+        video_row.time_created = time_created;
         video_row.flags = 0;
 
         return video_row.video_id;
@@ -188,15 +188,15 @@ public class VideoTable : DatabaseTable {
         row.clip_duration = stmt.column_double (3);
         row.is_interpretable = (stmt.column_int (4) == 1);
         row.filesize = stmt.column_int64 (5);
-        row.timestamp = (int64) stmt.column_int64 (6);
-        row.exposure_time = (int64) stmt.column_int64 (7);
+        row.timestamp = stmt.column_int64 (6);
+        row.exposure_time = stmt.column_int64 (7);
         row.import_id.id = stmt.column_int64 (8);
         row.event_id.id = stmt.column_int64 (9);
         row.md5 = stmt.column_text (10);
-        row.time_created = (int64) stmt.column_int64 (11);
+        row.time_created = stmt.column_int64 (11);
         row.title = stmt.column_text (12);
         row.backlinks = stmt.column_text (13);
-        row.time_reimported = (int64) stmt.column_int64 (14);
+        row.time_reimported = stmt.column_int64 (14);
         row.flags = stmt.column_int64 (15);
         row.comment = stmt.column_text (16);
 
@@ -252,7 +252,7 @@ public class VideoTable : DatabaseTable {
     }
 
     public void set_exposure_time (VideoID video_id, int64 time) throws DatabaseError {
-        update_int64_by_id_2 (video_id.id, "exposure_time", (int64) time);
+        update_int64_by_id_2 (video_id.id, "exposure_time", time);
     }
 
     public void set_flags (VideoID video_id, uint64 flags) throws DatabaseError {
@@ -410,6 +410,6 @@ public class VideoTable : DatabaseTable {
     }
 
     public void set_timestamp (VideoID video_id, int64 timestamp) throws DatabaseError {
-        update_int64_by_id_2 (video_id.id, "timestamp", (int64) timestamp);
+        update_int64_by_id_2 (video_id.id, "timestamp", timestamp);
     }
 }

--- a/src/db/VideoTable.vala
+++ b/src/db/VideoTable.vala
@@ -51,19 +51,19 @@ public class VideoRow {
     public VideoID video_id;
     public string filepath;
     public int64 filesize;
-    public time_t timestamp;
+    public int64 timestamp;
     public int width;
     public int height;
     public double clip_duration;
     public bool is_interpretable;
-    public time_t exposure_time;
+    public int64 exposure_time;
     public ImportID import_id;
     public EventID event_id;
     public string md5;
-    public time_t time_created;
+    public int64 time_created;
     public string title;
     public string? backlinks;
-    public time_t time_reimported;
+    public int64 time_reimported;
     public uint64 flags;
     public string comment;
 }
@@ -147,7 +147,7 @@ public class VideoTable : DatabaseTable {
         // fill in ignored fields with database values
         video_row.video_id = VideoID (db.last_insert_rowid ());
         video_row.event_id = EventID ();
-        video_row.time_created = (time_t) time_created;
+        video_row.time_created = (int64) time_created;
         video_row.flags = 0;
 
         return video_row.video_id;
@@ -188,15 +188,15 @@ public class VideoTable : DatabaseTable {
         row.clip_duration = stmt.column_double (3);
         row.is_interpretable = (stmt.column_int (4) == 1);
         row.filesize = stmt.column_int64 (5);
-        row.timestamp = (time_t) stmt.column_int64 (6);
-        row.exposure_time = (time_t) stmt.column_int64 (7);
+        row.timestamp = (int64) stmt.column_int64 (6);
+        row.exposure_time = (int64) stmt.column_int64 (7);
         row.import_id.id = stmt.column_int64 (8);
         row.event_id.id = stmt.column_int64 (9);
         row.md5 = stmt.column_text (10);
-        row.time_created = (time_t) stmt.column_int64 (11);
+        row.time_created = (int64) stmt.column_int64 (11);
         row.title = stmt.column_text (12);
         row.backlinks = stmt.column_text (13);
-        row.time_reimported = (time_t) stmt.column_int64 (14);
+        row.time_reimported = (int64) stmt.column_int64 (14);
         row.flags = stmt.column_int64 (15);
         row.comment = stmt.column_text (16);
 
@@ -221,15 +221,15 @@ public class VideoTable : DatabaseTable {
             row.clip_duration = stmt.column_double (4);
             row.is_interpretable = (stmt.column_int (5) == 1);
             row.filesize = stmt.column_int64 (6);
-            row.timestamp = (time_t) stmt.column_int64 (7);
-            row.exposure_time = (time_t) stmt.column_int64 (8);
+            row.timestamp = (int64) stmt.column_int64 (7);
+            row.exposure_time = (int64) stmt.column_int64 (8);
             row.import_id.id = stmt.column_int64 (9);
             row.event_id.id = stmt.column_int64 (10);
             row.md5 = stmt.column_text (11);
-            row.time_created = (time_t) stmt.column_int64 (12);
+            row.time_created = (int64) stmt.column_int64 (12);
             row.title = stmt.column_text (13);
             row.backlinks = stmt.column_text (14);
-            row.time_reimported = (time_t) stmt.column_int64 (15);
+            row.time_reimported = (int64) stmt.column_int64 (15);
             row.flags = stmt.column_int64 (16);
             row.comment = stmt.column_text (17);
 
@@ -251,7 +251,7 @@ public class VideoTable : DatabaseTable {
         update_text_by_id_2 (video_id.id, "comment", new_comment != null ? new_comment : "");
     }
 
-    public void set_exposure_time (VideoID video_id, time_t time) throws DatabaseError {
+    public void set_exposure_time (VideoID video_id, int64 time) throws DatabaseError {
         update_int64_by_id_2 (video_id.id, "exposure_time", (int64) time);
     }
 
@@ -409,7 +409,7 @@ public class VideoTable : DatabaseTable {
         return result;
     }
 
-    public void set_timestamp (VideoID video_id, time_t timestamp) throws DatabaseError {
+    public void set_timestamp (VideoID video_id, int64 timestamp) throws DatabaseError {
         update_int64_by_id_2 (video_id.id, "timestamp", (int64) timestamp);
     }
 }

--- a/src/db/VideoTable.vala
+++ b/src/db/VideoTable.vala
@@ -221,15 +221,15 @@ public class VideoTable : DatabaseTable {
             row.clip_duration = stmt.column_double (4);
             row.is_interpretable = (stmt.column_int (5) == 1);
             row.filesize = stmt.column_int64 (6);
-            row.timestamp = (int64) stmt.column_int64 (7);
-            row.exposure_time = (int64) stmt.column_int64 (8);
+            row.timestamp = stmt.column_int64 (7);
+            row.exposure_time = stmt.column_int64 (8);
             row.import_id.id = stmt.column_int64 (9);
             row.event_id.id = stmt.column_int64 (10);
             row.md5 = stmt.column_text (11);
-            row.time_created = (int64) stmt.column_int64 (12);
+            row.time_created = stmt.column_int64 (12);
             row.title = stmt.column_text (13);
             row.backlinks = stmt.column_text (14);
-            row.time_reimported = (int64) stmt.column_int64 (15);
+            row.time_reimported = stmt.column_int64 (15);
             row.flags = stmt.column_int64 (16);
             row.comment = stmt.column_text (17);
 

--- a/src/events/Branch.vala
+++ b/src/events/Branch.vala
@@ -226,14 +226,14 @@ public class Events.Branch : Sidebar.Branch {
     }
 
     private void add_event (Event event) {
-        time_t event_time = event.get_start_time ();
+        int64 event_time = event.get_start_time ();
         if (event_time == 0) {
             add_undated_event (event);
 
             return;
         }
 
-        Time event_tm = Time.local (event_time);
+        DateTime event_tm = new DateTime.from_unix_local (event_time);
 
         Sidebar.Entry? year;
         Sidebar.Entry? month = find_event_month (event, event_tm, out year);
@@ -257,14 +257,14 @@ public class Events.Branch : Sidebar.Branch {
     }
 
     private void move_event (Event event) {
-        time_t event_time = event.get_start_time ();
+        int64 event_time = event.get_start_time ();
         if (event_time == 0) {
             move_to_undated_event (event);
 
             return;
         }
 
-        Time event_tm = Time.local (event_time);
+        DateTime event_tm = new DateTime.from_unix_local (event_time);
 
         Sidebar.Entry? year;
         Sidebar.Entry? month = find_event_month (event, event_tm, out year);
@@ -307,13 +307,13 @@ public class Events.Branch : Sidebar.Branch {
         }
     }
 
-    private Sidebar.Entry? find_event_month (Event event, Time event_tm, out Sidebar.Entry found_year) {
+    private Sidebar.Entry? find_event_month (Event event, DateTime event_tm, out Sidebar.Entry found_year) {
         // find the year first
         found_year = find_event_year (event, event_tm);
         if (found_year == null)
             return null;
 
-        int event_month = event_tm.month + 1;
+        int event_month = event_tm.get_month () + 1;
 
         // found the year, traverse the months
         return find_first_child (found_year, (entry) => {
@@ -321,8 +321,8 @@ public class Events.Branch : Sidebar.Branch {
         });
     }
 
-    private Sidebar.Entry? find_event_year (Event event, Time event_tm) {
-        int event_year = event_tm.year + 1900;
+    private Sidebar.Entry? find_event_year (Event event, DateTime event_tm) {
+        int event_year = event_tm.get_year ();
 
         return find_first_child (get_root (), (entry) => {
             if ((entry is Events.UndatedDirectoryEntry) || (entry is Events.NoEventEntry))
@@ -429,9 +429,9 @@ public class Events.MasterDirectoryEntry : Events.DirectoryEntry {
 
 public class Events.YearDirectoryEntry : Events.DirectoryEntry {
     private string name;
-    private Time tm;
+    private DateTime tm;
 
-    public YearDirectoryEntry (string name, Time tm) {
+    public YearDirectoryEntry (string name, DateTime tm) {
         this.name = name;
         this.tm = tm;
     }
@@ -441,7 +441,7 @@ public class Events.YearDirectoryEntry : Events.DirectoryEntry {
     }
 
     public int get_year () {
-        return tm.year + 1900;
+        return tm.get_year ();
     }
 
     protected override Page create_page () {
@@ -451,9 +451,9 @@ public class Events.YearDirectoryEntry : Events.DirectoryEntry {
 
 public class Events.MonthDirectoryEntry : Events.DirectoryEntry {
     private string name;
-    private Time tm;
+    private DateTime tm;
 
-    public MonthDirectoryEntry (string name, Time tm) {
+    public MonthDirectoryEntry (string name, DateTime tm) {
         this.name = name;
         this.tm = tm;
     }
@@ -463,11 +463,11 @@ public class Events.MonthDirectoryEntry : Events.DirectoryEntry {
     }
 
     public int get_year () {
-        return tm.year + 1900;
+        return tm.get_year ();
     }
 
     public int get_month () {
-        return tm.month + 1;
+        return tm.get_month () + 1;
     }
 
     protected override Page create_page () {
@@ -485,7 +485,7 @@ public class Events.UndatedDirectoryEntry : Events.DirectoryEntry {
 
     protected override Page create_page () {
         return new SubEventsDirectoryPage (SubEventsDirectoryPage.DirectoryType.UNDATED,
-                                           Time.local (0));
+                                           new DateTime.now ());
     }
 }
 

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -702,25 +702,25 @@ public class PhotoMetadata : MediaMetadata {
         exiv2.clear ();
     }
 
-    private static string[] date_time_tags = {
+    private static string[] date_int64ags = {
         "Exif.Image.DateTime",
         "Xmp.tiff.DateTime",
         "Xmp.xmp.ModifyDate"
     };
 
     public MetadataDateTime? get_modification_date_time () {
-        return get_first_date_time (date_time_tags);
+        return get_first_date_time (date_int64ags);
     }
 
     public void set_modification_date_time (MetadataDateTime? date_time,
                                             SetOption option = SetOption.ALL_DOMAINS) {
         if (date_time != null)
-            set_all_date_time (date_time_tags, date_time, option);
+            set_all_date_time (date_int64ags, date_time, option);
         else
-            remove_tags (date_time_tags);
+            remove_tags (date_int64ags);
     }
 
-    private static string[] exposure_date_time_tags = {
+    private static string[] exposure_date_int64ags = {
         "Exif.Photo.DateTimeOriginal",
         "Xmp.exif.DateTimeOriginal",
         "Xmp.xmp.CreateDate",
@@ -730,32 +730,32 @@ public class PhotoMetadata : MediaMetadata {
     };
 
     public MetadataDateTime? get_exposure_date_time () {
-        return get_first_date_time (exposure_date_time_tags);
+        return get_first_date_time (exposure_date_int64ags);
     }
 
     public void set_exposure_date_time (MetadataDateTime? date_time,
                                         SetOption option = SetOption.ALL_DOMAINS) {
         if (date_time != null)
-            set_all_date_time (exposure_date_time_tags, date_time, option);
+            set_all_date_time (exposure_date_int64ags, date_time, option);
         else
-            remove_tags (exposure_date_time_tags);
+            remove_tags (exposure_date_int64ags);
     }
 
-    private static string[] digitized_date_time_tags = {
+    private static string[] digitized_date_int64ags = {
         "Exif.Photo.DateTimeDigitized",
         "Xmp.exif.DateTimeDigitized"
     };
 
     public MetadataDateTime? get_digitized_date_time () {
-        return get_first_date_time (digitized_date_time_tags);
+        return get_first_date_time (digitized_date_int64ags);
     }
 
     public void set_digitized_date_time (MetadataDateTime? date_time,
                                          SetOption option = SetOption.ALL_DOMAINS) {
         if (date_time != null)
-            set_all_date_time (digitized_date_time_tags, date_time, option);
+            set_all_date_time (digitized_date_int64ags, date_time, option);
         else
-            remove_tags (digitized_date_time_tags);
+            remove_tags (digitized_date_int64ags);
     }
 
     public override MetadataDateTime? get_creation_date_time () {

--- a/src/searches/SearchBoolean.vala
+++ b/src/searches/SearchBoolean.vala
@@ -717,7 +717,7 @@ public class SearchConditionDate : SearchCondition {
 
     // Determines whether the source is included.
     public override bool predicate (MediaSource source) {
-        time_t exposure_time = source.get_exposure_time ();
+        int64 exposure_time = source.get_exposure_time ();
         if (exposure_time == 0)
             return context == Context.IS_NOT_SET;
 

--- a/src/sidebar/metadata/BasicProperties.vala
+++ b/src/sidebar/metadata/BasicProperties.vala
@@ -18,8 +18,8 @@
 */
 
 private class BasicProperties : Properties {
-    private time_t start_time = time_t ();
-    private time_t end_time = time_t ();
+    private int64 start_time = 0;
+    private int64 end_time = 0;
     private Dimensions dimensions;
     private EditableTitle title_entry;
     private MediaSource? source;
@@ -167,7 +167,7 @@ private class BasicProperties : Properties {
             DataSource source = view.source;
 
             if (source is PhotoSource || source is PhotoImportSource) {
-                time_t exposure_time = (source is PhotoSource) ?
+                int64 exposure_time = (source is PhotoSource) ?
                                        ((PhotoSource) source).get_exposure_time () :
                                        ((PhotoImportSource) source).get_exposure_time ();
 
@@ -206,7 +206,7 @@ private class BasicProperties : Properties {
                 video_count += event_video_count;
                 event_count++;
             } else if (source is VideoSource || source is VideoImportSource) {
-                time_t exposure_time = (source is VideoSource) ?
+                int64 exposure_time = (source is VideoSource) ?
                                        ((VideoSource) source).get_exposure_time () :
                                        ((VideoImportSource) source).get_exposure_time ();
 
@@ -262,10 +262,10 @@ private class BasicProperties : Properties {
         }
 
         if (start_time != 0) {
-            string start_date = get_prettyprint_date (Time.local (start_time));
-            string start_time = get_prettyprint_time (Time.local (start_time));
-            string end_date = get_prettyprint_date (Time.local (end_time));
-            string end_time = get_prettyprint_time (Time.local (end_time));
+            string start_date = get_prettyprint_date (new DateTime.from_unix_local (start_time));
+            string start_time = get_prettyprint_time (new DateTime.from_unix_local (start_time));
+            string end_date = get_prettyprint_date (new DateTime.from_unix_local (end_time));
+            string end_time = get_prettyprint_time (new DateTime.from_unix_local (end_time));
 
             if (start_date == end_date) {
                 if (start_time == end_time) {

--- a/src/sidebar/metadata/BasicProperties.vala
+++ b/src/sidebar/metadata/BasicProperties.vala
@@ -262,10 +262,12 @@ private class BasicProperties : Properties {
         }
 
         if (start_time != 0) {
-            string start_date = get_prettyprint_date (new DateTime.from_unix_local (start_time));
-            string start_time = get_prettyprint_time (new DateTime.from_unix_local (start_time));
-            string end_date = get_prettyprint_date (new DateTime.from_unix_local (end_time));
-            string end_time = get_prettyprint_time (new DateTime.from_unix_local (end_time));
+            var start_dt = new DateTime.from_unix_local (start_time);
+            string start_date = get_prettyprint_date (start_dt);
+            string start_time = get_prettyprint_time (start_dt);
+            var end_dt = new DateTime.from_unix_local (end_time);
+            string end_date = get_prettyprint_date (end_dt);
+            string end_time = get_prettyprint_time (end_dt);
 
             if (start_date == end_date) {
                 if (start_time == end_time) {

--- a/src/sidebar/metadata/ExtendedProperties.vala
+++ b/src/sidebar/metadata/ExtendedProperties.vala
@@ -94,8 +94,9 @@ private class ExtendedProperties : Properties {
             artist = metadata.get_artist ();
             copyright = metadata.get_copyright ();
             int64 exposure_time_obj = metadata.get_exposure_date_time ().get_timestamp ();
-            exposure_date = get_prettyprint_date (new DateTime.from_unix_local (exposure_time_obj));
-            exposure_time = get_prettyprint_time_with_seconds (new DateTime.from_unix_local (exposure_time_obj));
+            var exposure_dt = new DateTime.from_unix_local (exposure_time_obj);
+            exposure_date = get_prettyprint_date (exposure_dt);
+            exposure_time = get_prettyprint_time_with_seconds (exposure_dt);
             comment = media.get_comment ();
         } else if (source is EventSource) {
             Event event = (Event) source;

--- a/src/sidebar/metadata/ExtendedProperties.vala
+++ b/src/sidebar/metadata/ExtendedProperties.vala
@@ -93,9 +93,9 @@ private class ExtendedProperties : Properties {
             is_raw = (photo.get_master_file_format () == PhotoFileFormat.RAW);
             artist = metadata.get_artist ();
             copyright = metadata.get_copyright ();
-            time_t exposure_time_obj = metadata.get_exposure_date_time ().get_timestamp ();
-            exposure_date = get_prettyprint_date (Time.local (exposure_time_obj));
-            exposure_time = get_prettyprint_time_with_seconds (Time.local (exposure_time_obj));
+            int64 exposure_time_obj = metadata.get_exposure_date_time ().get_timestamp ();
+            exposure_date = get_prettyprint_date (new DateTime.from_unix_local (exposure_time_obj));
+            exposure_time = get_prettyprint_time_with_seconds (new DateTime.from_unix_local (exposure_time_obj));
             comment = media.get_comment ();
         } else if (source is EventSource) {
             Event event = (Event) source;

--- a/src/sidebar/metadata/Properties.vala
+++ b/src/sidebar/metadata/Properties.vala
@@ -40,7 +40,7 @@ public abstract class Properties : Gtk.Grid {
         line_count++;
     }
 
-    protected string get_prettyprint_time (Time time) {
+    protected string get_prettyprint_time (DateTime time) {
         string timestring = time.format (Resources.get_hh_mm_format_string ());
 
         if (timestring[0] == '0')
@@ -49,7 +49,7 @@ public abstract class Properties : Gtk.Grid {
         return timestring;
     }
 
-    protected string get_prettyprint_time_with_seconds (Time time) {
+    protected string get_prettyprint_time_with_seconds (DateTime time) {
         string timestring = time.format (Resources.get_hh_mm_ss_format_string ());
 
         if (timestring[0] == '0')
@@ -58,12 +58,12 @@ public abstract class Properties : Gtk.Grid {
         return timestring;
     }
 
-    protected string get_prettyprint_date (Time date) {
+    protected string get_prettyprint_date (DateTime date) {
         string date_string = null;
-        Time today = Time.local (time_t ());
-        if (date.day_of_year == today.day_of_year && date.year == today.year) {
+        var today = new DateTime.now ();
+        if (date.get_day_of_year () == today.get_day_of_year () && date.get_year () == today.get_year ()) {
             date_string = _ ("Today");
-        } else if (date.day_of_year == (today.day_of_year - 1) && date.year == today.year) {
+        } else if (date.get_day_of_year () == (today.get_day_of_year () - 1) && date.get_year () == today.get_year ()) {
             date_string = _ ("Yesterday");
         } else {
             date_string = format_local_date (date);

--- a/src/slideshow/TransitionEffects.vala
+++ b/src/slideshow/TransitionEffects.vala
@@ -142,7 +142,7 @@ public class TransitionClock {
     private Spit.Transitions.Motion? motion = null;
     private unowned RepaintCallback? repaint = null;
     private uint timer_id = 0;
-    private ulong time_started = 0;
+    private int64 time_started = 0;
     private int frame_number = 0;
     private bool cancelled = false;
 

--- a/src/util/file.vala
+++ b/src/util/file.vala
@@ -164,7 +164,7 @@ public void delete_all_files (File dir, Gee.Set<string>? exceptions = null, Prog
     }
 }
 
-public time_t query_file_modified (File file) throws Error {
+public int64 query_file_modified (File file) throws Error {
     FileInfo info = file.query_info (FileAttribute.TIME_MODIFIED, FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
     null);
 

--- a/src/util/misc.vala
+++ b/src/util/misc.vala
@@ -67,22 +67,16 @@ public bool int_value_equals (Value a, Value b) {
     return (int) a == (int) b;
 }
 
-public ulong timeval_to_ms (TimeVal time_val) {
-    return (((ulong) time_val.tv_sec) * 1000) + (((ulong) time_val.tv_usec) / 1000);
+public int64 now_ms () {
+    var date_time_now = new DateTime.now_local ();
+
+    return date_time_now.to_unix () * 1000 + date_time_now.get_microsecond () / 1000;
 }
 
-public ulong now_ms () {
-    return timeval_to_ms (TimeVal ());
-}
+public int64 now_sec () {
+    var date_time_now = new DateTime.now_local ();
 
-public ulong now_sec () {
-    TimeVal time_val = TimeVal ();
-
-    return time_val.tv_sec;
-}
-
-public inline int64 now_int64 () {
-    return (int64) now_sec ();
+    return date_time_now.to_unix ();
 }
 
 public string md5_binary (uint8 *buffer, size_t length) {

--- a/src/util/misc.vala
+++ b/src/util/misc.vala
@@ -81,8 +81,8 @@ public ulong now_sec () {
     return time_val.tv_sec;
 }
 
-public inline time_t now_time_t () {
-    return (time_t) now_sec ();
+public inline int64 now_int64 () {
+    return (int64) now_sec ();
 }
 
 public string md5_binary (uint8 *buffer, size_t length) {
@@ -238,14 +238,14 @@ public Gee.List<MediaSource>? unserialize_media_sources (uchar *serialized, int 
     return list;
 }
 
-public string format_local_datespan (Time from_date, Time to_date) {
+public string format_local_datespan (DateTime from_date, DateTime to_date) {
     string from_format, to_format;
 
     // Ticket #3240 - Change the way date ranges are pretty-
     // printed if the start and end date occur on consecutive days.
-    if (from_date.year == to_date.year) {
+    if (from_date.get_year () == to_date.get_year ()) {
         // are these consecutive dates?
-        if ((from_date.month == to_date.month) && (from_date.day == (to_date.day - 1))) {
+        if ((from_date.get_month () == to_date.get_month ()) && (from_date.get_day_of_month () == (to_date.get_day_of_month () - 1))) {
             // Yes; display like so: Sat, July 4 - 5, 20X6
             from_format = Resources.get_start_multiday_span_format_string ();
             to_format = Resources.get_end_multiday_span_format_string ();
@@ -266,7 +266,7 @@ public string format_local_datespan (Time from_date, Time to_date) {
                                         to_date.format (to_format)));
 }
 
-public string format_local_date (Time date) {
+public string format_local_date (DateTime date) {
     return String.strip_leading_zeroes (date.format (Resources.get_long_date_format_string ()));
 }
 


### PR DESCRIPTION
In preparation for 2038 ...

Replaced `time_t` types with `int64` and use `GLib.DateTime` instead of `GLib.TimeVal` and `GLib.Time`

No regressions found so far browsing my existing photos and videos but needs thorough testing for corner cases, time-zone effects etc.