### PR TITLE
Fix empty more options

### DIFF
--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -155,10 +155,9 @@ public abstract class EditingHostPage : SinglePhotoPage {
             enhance_button.clicked.connect (on_enhance);
             enhance_button.create_menu_proxy.connect (() => {
                 var enhance_menu_item = new Gtk.CheckMenuItem.with_label ("Enhance");
-                enhance_menu_item.active = has_photo () && get_photo ().is_enhanced ();
+                enhance_menu_item.active = enhance_button.active;
                 enhance_menu_item.activate.connect (() => {
-                    on_enhance ();
-                    enhance_menu_item.active = has_photo () && get_photo ().is_enhanced ();
+                    enhance_button.clicked ();
                 });
                 enhance_button.set_proxy_menu_item ("Enhance", enhance_menu_item);
                 return true;

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -161,10 +161,13 @@ public abstract class EditingHostPage : SinglePhotoPage {
                 return true;
             });
 
-            var separator = new Gtk.SeparatorToolItem ();
-            separator.set_expand (true);
+            var expanding_separator = new Gtk.SeparatorToolItem ();
+            expanding_separator.set_expand (true);
 
-            var zoom_fit = new Gtk.Button.from_icon_name ("zoom-fit-best-symbolic", Gtk.IconSize.MENU);
+            var zoom_fit = new Gtk.ToolButton (
+                new Gtk.Image.from_icon_name ("zoom-fit-best-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+                 _("Zoom to fit page")
+            );
             zoom_fit.tooltip_text = _("Zoom to fit page");
             zoom_fit.valign = Gtk.Align.CENTER;
             zoom_fit.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
@@ -173,7 +176,19 @@ public abstract class EditingHostPage : SinglePhotoPage {
             zoom_fit_action.bind_property ("sensitive", zoom_fit, "sensitive", BindingFlags.SYNC_CREATE);
             zoom_fit.clicked.connect (() => zoom_fit_action.activate ());
 
-            var zoom_original = new Gtk.Button.from_icon_name ("zoom-original-symbolic", Gtk.IconSize.MENU);
+            zoom_fit.create_menu_proxy.connect (() => {
+                var zoom_fit_menu_item = new Gtk.MenuItem.with_label (_("Fit to page"));
+                zoom_fit_menu_item.activate.connect (() => {
+                    zoom_fit.clicked ();
+                });
+                zoom_fit.set_proxy_menu_item ("ZoomFit", zoom_fit_menu_item);
+                return true;
+            });
+
+            var zoom_original = new Gtk.ToolButton (
+                new Gtk.Image.from_icon_name ("zoom-original-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+                 _("Zoom 1:1")
+            );
             zoom_original.tooltip_text = _("Zoom 1:1");
             zoom_original.valign = Gtk.Align.CENTER;
             zoom_original.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
@@ -181,17 +196,22 @@ public abstract class EditingHostPage : SinglePhotoPage {
                 snap_zoom_to_isomorphic ();
             });
 
-            zoom_slider = new SliderAssembly (0, 1.1, 0.1, 0);
+            zoom_original.create_menu_proxy.connect (() => {
+                var zoom_original_menu_item = new Gtk.MenuItem.with_label (_("Restore original size"));
+                zoom_original_menu_item.activate.connect (() => {
+                    zoom_original.clicked ();
+                });
+                zoom_original.set_proxy_menu_item ("ZoomOriginal", zoom_original_menu_item);
+                return true;
+            });
+
+            zoom_slider = new SliderAssembly (0, 1.1, 0.1, 0); // Now subclass of Gtk.ToolItem
             zoom_slider.value_changed.connect (on_zoom_slider_value_changed);
-
-            var zoom_group = new Gtk.Grid ();
-            zoom_group.column_spacing = 6;
-            zoom_group.add (zoom_fit);
-            zoom_group.add (zoom_original);
-            zoom_group.add (zoom_slider);
-
-            var group_wrapper = new Gtk.ToolItem ();
-            group_wrapper.add (zoom_group);
+            //Not simple to create a proxy menu item for the slider so we don't for now
+            zoom_slider.create_menu_proxy.connect (() => {
+                zoom_slider.set_proxy_menu_item ("ZoomSlider", null);
+                return true;
+            });
 
             prev_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
             prev_button.tooltip_text = _("Previous photo");
@@ -214,8 +234,11 @@ public abstract class EditingHostPage : SinglePhotoPage {
             toolbar.add (redeye_button);
             toolbar.add (adjust_button);
             toolbar.add (enhance_button);
-            toolbar.add (separator);
-            toolbar.add (group_wrapper);
+            toolbar.add (expanding_separator);
+            toolbar.add (zoom_fit);
+            toolbar.add (zoom_original);
+            toolbar.add (zoom_slider);
+
 
             //  show metadata sidebar button
             var app = AppWindow.get_instance () as LibraryWindow;

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -225,12 +225,12 @@ public abstract class EditingHostPage : SinglePhotoPage {
                     app.set_metadata_sidebar_visible (!app.is_metadata_sidebar_visible ());
                     update_sidebar_action (!app.is_metadata_sidebar_visible ());
                 });
+
                 show_sidebar_button.create_menu_proxy.connect (() => {
                     var show_sidebar_item = new Gtk.CheckMenuItem.with_label ("Show Sidebar");
                     show_sidebar_item.active = app.is_metadata_sidebar_visible ();
-                    show_sidebar_item.toggled.connect (() => {
-                        app.set_metadata_sidebar_visible (!app.is_metadata_sidebar_visible ());
-                        update_sidebar_action (!app.is_metadata_sidebar_visible ());
+                    show_sidebar_item.activate.connect (() => {
+                        show_sidebar_button.clicked ();
                     });
 
                     show_sidebar_button.set_proxy_menu_item ("Sidebar", show_sidebar_item);
@@ -238,7 +238,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
                 });
                 toolbar.add (show_sidebar_button);
                 update_sidebar_action (!app.is_metadata_sidebar_visible ());
-            } else {critical ("app null");}
+            }
         }
 
         return toolbar;

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -128,6 +128,14 @@ public abstract class EditingHostPage : SinglePhotoPage {
             redeye_button.icon_widget = new Gtk.Image.from_icon_name ("image-red-eye", Gtk.IconSize.LARGE_TOOLBAR);
             redeye_button.tooltip_text = Resources.RED_EYE_TOOLTIP;
             redeye_button.toggled.connect (on_redeye_toggled);
+            redeye_button.create_menu_proxy.connect (() => {
+                var redeye_menu_item = new Gtk.MenuItem.with_label ("Red Eye Correction");
+                redeye_menu_item.activate.connect (() => {
+                    redeye_button.active = true;
+                });
+                redeye_button.set_proxy_menu_item ("RedEye", redeye_menu_item);
+                return true;
+            });
 
             adjust_button = new Gtk.ToggleToolButton ();
             adjust_button.icon_widget = new Gtk.Image.from_icon_name ("image-adjust", Gtk.IconSize.LARGE_TOOLBAR);

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -133,7 +133,14 @@ public abstract class EditingHostPage : SinglePhotoPage {
             adjust_button.icon_widget = new Gtk.Image.from_icon_name ("image-adjust", Gtk.IconSize.LARGE_TOOLBAR);
             adjust_button.tooltip_text = Resources.ADJUST_TOOLTIP;
             adjust_button.toggled.connect (on_adjust_toggled);
-
+            adjust_button.create_menu_proxy.connect (() => {
+                var adjust_menu_item = new Gtk.MenuItem.with_label ("Adjust");
+                adjust_menu_item.activate.connect (() => {
+                    adjust_button.active = true;
+                });
+                adjust_button.set_proxy_menu_item ("Enhance", adjust_menu_item);
+                return true;
+            });
             enhance_button = new Gtk.ToggleToolButton (); // Not sure why this is a toggle
             enhance_button.icon_widget = new Gtk.Image.from_icon_name ("image-auto-adjust", Gtk.IconSize.LARGE_TOOLBAR);
             enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -107,8 +107,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
             rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
             rotate_button.clicked.connect (on_rotate_clockwise);
 
-
-
             flip_button = new Gtk.ToolButton (null, null);
             flip_button.icon_name = "object-flip-horizontal";
             flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
@@ -129,7 +127,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
             redeye_button.tooltip_text = Resources.RED_EYE_TOOLTIP;
             redeye_button.toggled.connect (on_redeye_toggled);
             redeye_button.create_menu_proxy.connect (() => {
-                var redeye_menu_item = new Gtk.MenuItem.with_label ("Red Eye Correction");
+                var redeye_menu_item = new Gtk.MenuItem.with_label (Resources.RED_EYE_LABEL);
                 redeye_menu_item.activate.connect (() => {
                     redeye_button.active = true;
                 });
@@ -142,11 +140,11 @@ public abstract class EditingHostPage : SinglePhotoPage {
             adjust_button.tooltip_text = Resources.ADJUST_TOOLTIP;
             adjust_button.toggled.connect (on_adjust_toggled);
             adjust_button.create_menu_proxy.connect (() => {
-                var adjust_menu_item = new Gtk.MenuItem.with_label ("Adjust");
+                var adjust_menu_item = new Gtk.MenuItem.with_label (Resources.ADJUST_LABEL);
                 adjust_menu_item.activate.connect (() => {
                     adjust_button.active = true;
                 });
-                adjust_button.set_proxy_menu_item ("Enhance", adjust_menu_item);
+                adjust_button.set_proxy_menu_item ("Adjust", adjust_menu_item);
                 return true;
             });
             enhance_button = new Gtk.ToggleToolButton (); // Not sure why this is a toggle
@@ -154,7 +152,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
             enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
             enhance_button.clicked.connect (on_enhance);
             enhance_button.create_menu_proxy.connect (() => {
-                var enhance_menu_item = new Gtk.CheckMenuItem.with_label ("Enhance");
+                var enhance_menu_item = new Gtk.CheckMenuItem.with_label (Resources.ENHANCE_LABEL);
                 enhance_menu_item.active = enhance_button.active;
                 enhance_menu_item.activate.connect (() => {
                     enhance_button.clicked ();

--- a/src/Widgets/SliderAssembly.vala
+++ b/src/Widgets/SliderAssembly.vala
@@ -18,7 +18,7 @@
 * Authored by: David Hewitt <davidmhewitt@gmail.com>
 */
 
-public class SliderAssembly : Gtk.Grid {
+public class SliderAssembly : Gtk.ToolItem {
     private Gtk.Scale slider;
     private Gtk.EventBox decrease_box;
     private Gtk.EventBox increase_box;
@@ -53,9 +53,10 @@ public class SliderAssembly : Gtk.Grid {
     }
 
     construct {
-        orientation = Gtk.Orientation.HORIZONTAL;
-        margin_top = 5;
-        margin_bottom = 5;
+        var grid = new Gtk.Grid () {
+            orientation = Gtk.Orientation.HORIZONTAL,
+            valign = Gtk.Align.CENTER
+        };
 
         var decrease = new Gtk.Image.from_icon_name (Resources.ICON_ZOOM_OUT, Gtk.IconSize.MENU);
         decrease_box = new Gtk.EventBox ();
@@ -70,14 +71,14 @@ public class SliderAssembly : Gtk.Grid {
             return false;
         });
 
-        add (decrease_box);
+        grid.add (decrease_box);
 
         slider = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, null);
         slider.value_changed.connect (on_slider_value_changed);
         slider.draw_value = false;
         slider.set_size_request (150, -1);
 
-        add (slider);
+        grid.add (slider);
 
         var increase = new Gtk.Image.from_icon_name (Resources.ICON_ZOOM_IN, Gtk.IconSize.MENU);
         increase_box = new Gtk.EventBox ();
@@ -92,7 +93,9 @@ public class SliderAssembly : Gtk.Grid {
             return false;
         });
 
-        add (increase_box);
+        grid.add (increase_box);
+        add (grid);
+        show_all ();
     }
 
     public SliderAssembly (double min, double max, double step, double initial_val) {


### PR DESCRIPTION
Fixes #615 

 - [x] Show sidebar
 - [x] Enhance
 - [x] Adjust
 - [x] Redeye correction
 - [x] Zoom Group (Fit and Original size)
 - [ ] Zoom Group (Slider)


Tools to the left of the Redeye tool are always displayable because of the minimum width of the headerbar so do not need proxy menu items (afaict).