### PR TITLE
Substitute ActionBar for Toolbar

### DIFF
--- a/src/FullScreenWindow.vala
+++ b/src/FullScreenWindow.vala
@@ -24,7 +24,7 @@ public class FullscreenWindow : PageWindow {
 
     private Gtk.Revealer revealer;
     private Gtk.ActionBar toolbar;
-    private Gtk.ToggleToolButton pin_button;
+    private Gtk.ToggleButton pin_button;
     private int64 left_toolbar_time = 0;
     private bool switched_to = false;
 
@@ -47,14 +47,12 @@ public class FullscreenWindow : PageWindow {
 
         set_border_width (0);
 
-        pin_button = new Gtk.ToggleToolButton ();
-        pin_button.icon_name = "view-pin-symbolic";
+        pin_button = new Gtk.ToggleButton ();
+        pin_button.image = new Gtk.Image.from_icon_name ("view-pin-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         pin_button.tooltip_text = _("Pin the toolbar open");
         pin_button.bind_property ("active", this, "auto-dismiss-toolbar", GLib.BindingFlags.INVERT_BOOLEAN);
 
-        var img = new Gtk.Image.from_icon_name ("window-restore-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-
-        var close_button = new Gtk.ToolButton (img, null);
+        var close_button = new Gtk.Button.from_icon_name ("window-restore-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         close_button.tooltip_text = _("Leave fullscreen");
         close_button.clicked.connect (on_close);
 

--- a/src/FullScreenWindow.vala
+++ b/src/FullScreenWindow.vala
@@ -23,7 +23,7 @@ public class FullscreenWindow : PageWindow {
     public const int TOOLBAR_CHECK_DISMISSAL_MSEC = 500;
 
     private Gtk.Revealer revealer;
-    private Gtk.Toolbar toolbar;
+    private Gtk.ActionBar toolbar;
     private Gtk.ToggleToolButton pin_button;
     private int64 left_toolbar_time = 0;
     private bool switched_to = false;
@@ -68,13 +68,13 @@ public class FullscreenWindow : PageWindow {
             ((SlideshowPage) page).hide_toolbar.connect (hide_toolbar);
         } else {
             // only non-slideshow pages should have pin button
-            toolbar.insert (pin_button, -1);
+            toolbar.pack_end (pin_button);
         }
 
         page.set_cursor_hide_time (TOOLBAR_DISMISSAL_SEC * 1000);
         page.start_cursor_hiding ();
 
-        toolbar.insert (close_button, -1);
+        toolbar.pack_end (close_button);
 
         revealer = new Gtk.Revealer ();
         revealer.halign = Gtk.Align.CENTER;

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -48,76 +48,72 @@ public abstract class CollectionPage : MediaPage {
         show_all ();
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            var slideshow_button = new Gtk.ToolButton (null, _("S_lideshow"));
-            slideshow_button.icon_name = "media-playback-start-symbolic";
-            slideshow_button.tooltip_text = _("Play a slideshow");
-            slideshow_button.clicked.connect (on_slideshow);
+    public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        var slideshow_button = new Gtk.ToolButton (null, _("S_lideshow"));
+        slideshow_button.icon_name = "media-playback-start-symbolic";
+        slideshow_button.tooltip_text = _("Play a slideshow");
+        slideshow_button.clicked.connect (on_slideshow);
 
-            rotate_button = new Gtk.ToolButton (null, Resources.ROTATE_CW_MENU);
-            rotate_button.icon_name = Resources.CLOCKWISE;
-            rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
-            rotate_button.clicked.connect (on_rotate_clockwise);
+        rotate_button = new Gtk.ToolButton (null, Resources.ROTATE_CW_MENU);
+        rotate_button.icon_name = Resources.CLOCKWISE;
+        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
+        rotate_button.clicked.connect (on_rotate_clockwise);
 
-            var rotate_action = get_action ("RotateClockwise");
-            rotate_action.bind_property ("sensitive", rotate_button, "sensitive", BindingFlags.SYNC_CREATE);
+        var rotate_action = get_action ("RotateClockwise");
+        rotate_action.bind_property ("sensitive", rotate_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-            flip_button = new Gtk.ToolButton (null, Resources.HFLIP_MENU);
-            flip_button.icon_name = Resources.HFLIP;
-            flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
-            flip_button.clicked.connect (on_flip_horizontally);
+        flip_button = new Gtk.ToolButton (null, Resources.HFLIP_MENU);
+        flip_button.icon_name = Resources.HFLIP;
+        flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
+        flip_button.clicked.connect (on_flip_horizontally);
 
-            var flip_action = get_action ("FlipHorizontally");
-            flip_action.bind_property ("sensitive", flip_button, "sensitive", BindingFlags.SYNC_CREATE);
+        var flip_action = get_action ("FlipHorizontally");
+        flip_action.bind_property ("sensitive", flip_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-            var publish_button = new Gtk.ToolButton (null, Resources.PUBLISH_MENU);
-            publish_button.icon_name = Resources.PUBLISH;
-            publish_button.tooltip_text = Resources.PUBLISH_TOOLTIP;
-            publish_button.clicked.connect (on_publish);
+        var publish_button = new Gtk.ToolButton (null, Resources.PUBLISH_MENU);
+        publish_button.icon_name = Resources.PUBLISH;
+        publish_button.tooltip_text = Resources.PUBLISH_TOOLTIP;
+        publish_button.clicked.connect (on_publish);
 
-            var publish_action = get_action ("Publish");
-            publish_action.bind_property ("sensitive", publish_button, "sensitive", BindingFlags.SYNC_CREATE);
+        var publish_action = get_action ("Publish");
+        publish_action.bind_property ("sensitive", publish_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-            enhance_button = new Gtk.ToggleToolButton ();
-            enhance_button.icon_name = Resources.ENHANCE;
-            enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
-            enhance_button.clicked.connect (on_enhance);
+        enhance_button = new Gtk.ToggleToolButton ();
+        enhance_button.icon_name = Resources.ENHANCE;
+        enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
+        enhance_button.clicked.connect (on_enhance);
 
-            var separator = new Gtk.SeparatorToolItem ();
-            separator.set_expand (true);
-            separator.set_draw (false);
+        var separator = new Gtk.SeparatorToolItem ();
+        separator.set_expand (true);
+        separator.set_draw (false);
 
-            var zoom_assembly = new SliderAssembly (Thumbnail.MIN_SCALE,
-                                                    Thumbnail.MAX_SCALE,
-                                                    MediaPage.MANUAL_STEPPING, 0);
+        var zoom_assembly = new SliderAssembly (Thumbnail.MIN_SCALE,
+                                                Thumbnail.MAX_SCALE,
+                                                MediaPage.MANUAL_STEPPING, 0);
 
-            zoom_assembly.tooltip = _("Adjust the size of the thumbnails");
-            connect_slider (zoom_assembly);
+        zoom_assembly.tooltip = _("Adjust the size of the thumbnails");
+        connect_slider (zoom_assembly);
 
-            var group_wrapper = new Gtk.ToolItem ();
-            group_wrapper.add (zoom_assembly);
+        var group_wrapper = new Gtk.ToolItem ();
+        group_wrapper.add (zoom_assembly);
 
-            show_sidebar_button = MediaPage.create_sidebar_button ();
-            show_sidebar_button.clicked.connect (on_show_sidebar);
+        show_sidebar_button = MediaPage.create_sidebar_button ();
+        show_sidebar_button.clicked.connect (on_show_sidebar);
 
-            toolbar = base.get_toolbar ();
-            toolbar.pack_start (slideshow_button);
-            toolbar.pack_start (rotate_button);
-            toolbar.pack_start (flip_button);
-            // toolbar.pack_start (new Gtk.SeparatorToolItem ());
-            toolbar.pack_start (publish_button);
-            // toolbar.pack_start (new Gtk.SeparatorToolItem ());
-            toolbar.pack_start (enhance_button);
-            toolbar.pack_end (show_sidebar_button);
-            toolbar.pack_end (group_wrapper);
+        toolbar.pack_start (slideshow_button);
+        toolbar.pack_start (rotate_button);
+        toolbar.pack_start (flip_button);
+        toolbar.pack_start (new Gtk.Separator (Gt.Orientation.VERTICAL));
+        toolbar.pack_start (publish_button);
+        toolbar.pack_start (new Gtk.Separator (Gt.Orientation.VERTICAL));
+        toolbar.pack_start (enhance_button);
+        toolbar.pack_end (show_sidebar_button);
+        toolbar.pack_end (group_wrapper);
 
 
-            var app = AppWindow.get_instance () as LibraryWindow;
-            update_sidebar_action (!app.is_metadata_sidebar_visible ());
-        }
-
-        return toolbar;
+        var app = AppWindow.get_instance () as LibraryWindow;
+        update_sidebar_action (!app.is_metadata_sidebar_visible ());
+        base.add_toolbar_widgets (toolbar);
     }
 
     public override Gtk.Menu? get_item_context_menu () {

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -99,8 +99,6 @@ public abstract class CollectionPage : MediaPage {
         toolbar.pack_start (enhance_button);
         toolbar.pack_end (show_sidebar_button);
         toolbar.pack_end (zoom_assembly);
-        // toolbar.pack_end (group_wrapper);
-
 
         var app = AppWindow.get_instance () as LibraryWindow;
         update_sidebar_action (!app.is_metadata_sidebar_visible ());

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -105,9 +105,9 @@ public abstract class CollectionPage : MediaPage {
             toolbar.pack_start (slideshow_button);
             toolbar.pack_start (rotate_button);
             toolbar.pack_start (flip_button);
-            toolbar.pack_start (new Gtk.SeparatorToolItem ());
+            // toolbar.pack_start (new Gtk.SeparatorToolItem ());
             toolbar.pack_start (publish_button);
-            toolbar.pack_start (new Gtk.SeparatorToolItem ());
+            // toolbar.pack_start (new Gtk.SeparatorToolItem ());
             toolbar.pack_start (enhance_button);
             toolbar.pack_end (show_sidebar_button);
             toolbar.pack_end (group_wrapper);

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -869,7 +869,7 @@ public abstract class CollectionPage : MediaPage {
     protected override bool on_ctrl_pressed (Gdk.EventKey? event) {
         flip_button.image = new Gtk.Image.from_icon_name (Resources.VFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.VFLIP_TOOLTIP;
-        rotate_button.image = new Gtk.Image.from_icon_name (Resources.COUNTERCLOCKWISE,  Gtk.IconSize.LARGE_TOOLBAR);
+        rotate_button.image = new Gtk.Image.from_icon_name (Resources.COUNTERCLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
         rotate_button.tooltip_text = Resources.ROTATE_CCW_TOOLTIP;
         flip_button.clicked.disconnect (on_flip_horizontally);
         flip_button.clicked.connect (on_flip_vertically);

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -29,14 +29,14 @@ public abstract class CollectionPage : MediaPage {
 
     private ExporterUI exporter = null;
     private CollectionSearchViewFilter search_filter = new CollectionSearchViewFilter ();
-    private Gtk.ToggleToolButton enhance_button = null;
+    private Gtk.ToggleButton? enhance_button = null;
     private Gtk.Menu item_context_menu;
     private Gtk.Menu open_menu;
     private Gtk.Menu open_raw_menu;
     private Gtk.MenuItem open_raw_menu_item;
     private Gtk.Menu contractor_menu;
-    private Gtk.ToolButton rotate_button;
-    private Gtk.ToolButton flip_button;
+    private Gtk.Button rotate_button;
+    private Gtk.Button flip_button;
 
     protected CollectionPage (string page_name) {
         Object (page_name: page_name);
@@ -49,43 +49,36 @@ public abstract class CollectionPage : MediaPage {
     }
 
     public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
-        var slideshow_button = new Gtk.ToolButton (null, _("S_lideshow"));
-        slideshow_button.icon_name = "media-playback-start-symbolic";
+        var slideshow_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic",
+                                                              Gtk.IconSize.LARGE_TOOLBAR);
         slideshow_button.tooltip_text = _("Play a slideshow");
         slideshow_button.clicked.connect (on_slideshow);
 
-        rotate_button = new Gtk.ToolButton (null, Resources.ROTATE_CW_MENU);
-        rotate_button.icon_name = Resources.CLOCKWISE;
-        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
+        rotate_button = new Gtk.Button.from_icon_name (Resources.CLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
+        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP; // Will be used be screen reader if no label
         rotate_button.clicked.connect (on_rotate_clockwise);
 
         var rotate_action = get_action ("RotateClockwise");
         rotate_action.bind_property ("sensitive", rotate_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-        flip_button = new Gtk.ToolButton (null, Resources.HFLIP_MENU);
-        flip_button.icon_name = Resources.HFLIP;
+        flip_button = new Gtk.Button.from_icon_name (Resources.HFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
         flip_button.clicked.connect (on_flip_horizontally);
 
         var flip_action = get_action ("FlipHorizontally");
         flip_action.bind_property ("sensitive", flip_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-        var publish_button = new Gtk.ToolButton (null, Resources.PUBLISH_MENU);
-        publish_button.icon_name = Resources.PUBLISH;
+        var publish_button = new Gtk.Button.from_icon_name (Resources.PUBLISH, Gtk.IconSize.LARGE_TOOLBAR);
         publish_button.tooltip_text = Resources.PUBLISH_TOOLTIP;
         publish_button.clicked.connect (on_publish);
 
         var publish_action = get_action ("Publish");
         publish_action.bind_property ("sensitive", publish_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-        enhance_button = new Gtk.ToggleToolButton ();
-        enhance_button.icon_name = Resources.ENHANCE;
+        enhance_button = new Gtk.ToggleButton ();
+        enhance_button.image = new Gtk.Image.from_icon_name (Resources.ENHANCE, Gtk.IconSize.LARGE_TOOLBAR);
         enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
         enhance_button.clicked.connect (on_enhance);
-
-        var separator = new Gtk.SeparatorToolItem ();
-        separator.set_expand (true);
-        separator.set_draw (false);
 
         var zoom_assembly = new SliderAssembly (Thumbnail.MIN_SCALE,
                                                 Thumbnail.MAX_SCALE,
@@ -94,21 +87,19 @@ public abstract class CollectionPage : MediaPage {
         zoom_assembly.tooltip = _("Adjust the size of the thumbnails");
         connect_slider (zoom_assembly);
 
-        var group_wrapper = new Gtk.ToolItem ();
-        group_wrapper.add (zoom_assembly);
-
         show_sidebar_button = MediaPage.create_sidebar_button ();
         show_sidebar_button.clicked.connect (on_show_sidebar);
 
         toolbar.pack_start (slideshow_button);
         toolbar.pack_start (rotate_button);
         toolbar.pack_start (flip_button);
-        toolbar.pack_start (new Gtk.Separator (Gt.Orientation.VERTICAL));
+        toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         toolbar.pack_start (publish_button);
-        toolbar.pack_start (new Gtk.Separator (Gt.Orientation.VERTICAL));
+        toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         toolbar.pack_start (enhance_button);
         toolbar.pack_end (show_sidebar_button);
-        toolbar.pack_end (group_wrapper);
+        toolbar.pack_end (zoom_assembly);
+        // toolbar.pack_end (group_wrapper);
 
 
         var app = AppWindow.get_instance () as LibraryWindow;
@@ -876,11 +867,9 @@ public abstract class CollectionPage : MediaPage {
     }
 
     protected override bool on_ctrl_pressed (Gdk.EventKey? event) {
-        flip_button.label = Resources.VFLIP_MENU;
-        flip_button.icon_name = Resources.VFLIP;
+        flip_button.image = new Gtk.Image.from_icon_name (Resources.VFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.VFLIP_TOOLTIP;
-        rotate_button.label = Resources.ROTATE_CCW_MENU;
-        rotate_button.icon_name = Resources.COUNTERCLOCKWISE;
+        rotate_button.image = new Gtk.Image.from_icon_name (Resources.COUNTERCLOCKWISE,  Gtk.IconSize.LARGE_TOOLBAR);
         rotate_button.tooltip_text = Resources.ROTATE_CCW_TOOLTIP;
         flip_button.clicked.disconnect (on_flip_horizontally);
         flip_button.clicked.connect (on_flip_vertically);
@@ -891,11 +880,9 @@ public abstract class CollectionPage : MediaPage {
     }
 
     protected override bool on_ctrl_released (Gdk.EventKey? event) {
-        flip_button.label = Resources.HFLIP_MENU;
-        flip_button.icon_name = Resources.HFLIP;
+        flip_button.image = new Gtk.Image.from_icon_name (Resources.HFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
-        rotate_button.label = Resources.ROTATE_CW_MENU;
-        rotate_button.icon_name = Resources.CLOCKWISE;
+        rotate_button.image = new Gtk.Image.from_icon_name (Resources.CLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
         rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
         flip_button.clicked.disconnect (on_flip_vertically);
         flip_button.clicked.connect (on_flip_horizontally);

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -48,7 +48,7 @@ public abstract class CollectionPage : MediaPage {
         show_all ();
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
             var slideshow_button = new Gtk.ToolButton (null, _("S_lideshow"));
             slideshow_button.icon_name = "media-playback-start-symbolic";
@@ -102,16 +102,16 @@ public abstract class CollectionPage : MediaPage {
             show_sidebar_button.clicked.connect (on_show_sidebar);
 
             toolbar = base.get_toolbar ();
-            toolbar.add (slideshow_button);
-            toolbar.add (rotate_button);
-            toolbar.add (flip_button);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (publish_button);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (enhance_button);
-            toolbar.add (separator);
-            toolbar.add (group_wrapper);
-            toolbar.add (show_sidebar_button);
+            toolbar.pack_start (slideshow_button);
+            toolbar.pack_start (rotate_button);
+            toolbar.pack_start (flip_button);
+            toolbar.pack_start (new Gtk.SeparatorToolItem ());
+            toolbar.pack_start (publish_button);
+            toolbar.pack_start (new Gtk.SeparatorToolItem ());
+            toolbar.pack_start (enhance_button);
+            toolbar.pack_end (show_sidebar_button);
+            toolbar.pack_end (group_wrapper);
+
 
             var app = AppWindow.get_instance () as LibraryWindow;
             update_sidebar_action (!app.is_metadata_sidebar_visible ());

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -51,18 +51,18 @@ public abstract class EditingHostPage : SinglePhotoPage {
     private ViewCollection? parent_view = null;
     private Gdk.Pixbuf swapped = null;
     private bool pixbuf_dirty = true;
-    protected Gtk.ToolButton rotate_button = null;
-    private Gtk.ToolButton flip_button = null;
-    private Gtk.ToggleToolButton crop_button = null;
-    private Gtk.ToggleToolButton redeye_button = null;
-    private Gtk.ToggleToolButton adjust_button = null;
-    private Gtk.ToggleToolButton straighten_button = null;
-    protected Gtk.ToggleToolButton enhance_button = null;
+    protected Gtk.Button? rotate_button = null;
+    private Gtk.Button? flip_button = null;
+    private Gtk.ToggleButton? crop_button = null;
+    private Gtk.ToggleButton? redeye_button = null;
+    private Gtk.ToggleButton? adjust_button = null;
+    private Gtk.ToggleButton? straighten_button = null;
+    protected Gtk.ToggleButton enhance_button = null;
     private SliderAssembly zoom_slider = null;
-    private Gtk.ToolButton prev_button = null;
-    private Gtk.ToolButton next_button = null;
+    private Gtk.Button prev_button = null;
+    private Gtk.Button next_button = null;
     private EditingTools.EditingTool current_tool = null;
-    private Gtk.ToggleToolButton current_editing_toggle = null;
+    private Gtk.ToggleButton current_editing_toggle = null;
     private Gdk.Pixbuf cancel_editing_pixbuf = null;
     private bool photo_missing = false;
     private PixbufCache cache = null;
@@ -100,42 +100,41 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
-        rotate_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR), _("Rotate"));
+        rotate_button = new Gtk.Button.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR);
         rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
         rotate_button.clicked.connect (on_rotate_clockwise);
 
-        flip_button = new Gtk.ToolButton (null, null);
-        flip_button.icon_name = "object-flip-horizontal";
+        flip_button = new Gtk.Button.from_icon_name ("object-flip-horizontal", Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
         flip_button.clicked.connect (on_flip_horizontally);
 
-        crop_button = new Gtk.ToggleToolButton ();
-        crop_button.icon_widget = new Gtk.Image.from_icon_name ("image-crop", Gtk.IconSize.LARGE_TOOLBAR);
+        crop_button = new Gtk.ToggleButton ();
+        crop_button.image = new Gtk.Image.from_icon_name ("image-crop", Gtk.IconSize.LARGE_TOOLBAR);
         crop_button.tooltip_text = Resources.CROP_TOOLTIP;
         crop_button.toggled.connect (on_crop_toggled);
 
-        straighten_button = new Gtk.ToggleToolButton ();
-        straighten_button.icon_widget = new Gtk.Image.from_icon_name ("object-straighten", Gtk.IconSize.LARGE_TOOLBAR);
+        straighten_button = new Gtk.ToggleButton ();
+        straighten_button.image = new Gtk.Image.from_icon_name ("object-straighten", Gtk.IconSize.LARGE_TOOLBAR);
         straighten_button.tooltip_text = Resources.STRAIGHTEN_TOOLTIP;
         straighten_button.toggled.connect (on_straighten_toggled);
 
-        redeye_button = new Gtk.ToggleToolButton ();
-        redeye_button.icon_widget = new Gtk.Image.from_icon_name ("image-red-eye", Gtk.IconSize.LARGE_TOOLBAR);
+        redeye_button = new Gtk.ToggleButton ();
+        redeye_button.image = new Gtk.Image.from_icon_name ("image-red-eye", Gtk.IconSize.LARGE_TOOLBAR);
         redeye_button.tooltip_text = Resources.RED_EYE_TOOLTIP;
         redeye_button.toggled.connect (on_redeye_toggled);
 
-        adjust_button = new Gtk.ToggleToolButton ();
-        adjust_button.icon_widget = new Gtk.Image.from_icon_name ("image-adjust", Gtk.IconSize.LARGE_TOOLBAR);
+        adjust_button = new Gtk.ToggleButton ();
+        adjust_button.image = new Gtk.Image.from_icon_name ("image-adjust", Gtk.IconSize.LARGE_TOOLBAR);
         adjust_button.tooltip_text = Resources.ADJUST_TOOLTIP;
         adjust_button.toggled.connect (on_adjust_toggled);
 
-        enhance_button = new Gtk.ToggleToolButton ();
-        enhance_button.icon_widget = new Gtk.Image.from_icon_name ("image-auto-adjust", Gtk.IconSize.LARGE_TOOLBAR);
+        enhance_button = new Gtk.ToggleButton ();
+        enhance_button.image = new Gtk.Image.from_icon_name ("image-auto-adjust", Gtk.IconSize.LARGE_TOOLBAR);
         enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
         enhance_button.clicked.connect (on_enhance);
 
-        var separator = new Gtk.SeparatorToolItem ();
-        separator.set_expand (true);
+        // var separator = new Gtk.SeparatorToolItem ();
+        // separator.set_expand (true);
 
         var zoom_fit = new Gtk.Button.from_icon_name ("zoom-fit-best-symbolic", Gtk.IconSize.MENU);
         zoom_fit.tooltip_text = _("Zoom to fit page");
@@ -166,11 +165,11 @@ public abstract class EditingHostPage : SinglePhotoPage {
         var group_wrapper = new Gtk.ToolItem ();
         group_wrapper.add (zoom_group);
 
-        prev_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
+        prev_button = new Gtk.Button.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         prev_button.tooltip_text = _("Previous photo");
         prev_button.clicked.connect (on_previous_photo);
 
-        next_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
+        next_button = new Gtk.Button.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         next_button.tooltip_text = _("Next photo");
         next_button.clicked.connect (on_next_photo);
 
@@ -188,7 +187,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
         toolbar.pack_start (redeye_button);
         toolbar.pack_start (adjust_button);
         toolbar.pack_start (enhance_button);
-        toolbar.pack_end (group_wrapper);
 
         //  show metadata sidebar button
         var app = AppWindow.get_instance () as LibraryWindow;
@@ -203,6 +201,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
             update_sidebar_action (!app.is_metadata_sidebar_visible ());
         }
 
+        toolbar.pack_end (group_wrapper);
         base.add_toolbar_widgets (toolbar);
     }
 
@@ -1598,14 +1597,13 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected override bool on_ctrl_pressed (Gdk.EventKey? event) {
-        rotate_button.set_icon_widget (new Gtk.Image.from_icon_name ("object-rotate-left", Gtk.IconSize.LARGE_TOOLBAR));
+        rotate_button.image = (new Gtk.Image.from_icon_name ("object-rotate-left", Gtk.IconSize.LARGE_TOOLBAR));
         rotate_button.set_tooltip_text (Resources.ROTATE_CCW_TOOLTIP);
         rotate_button.show_all ();
         rotate_button.clicked.disconnect (on_rotate_clockwise);
         rotate_button.clicked.connect (on_rotate_counterclockwise);
 
-        flip_button.set_icon_name (Resources.VFLIP);
-        flip_button.set_label (Resources.VFLIP_LABEL);
+        flip_button.image = new Gtk.Image.from_icon_name (Resources.VFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.set_tooltip_text (Resources.VFLIP_TOOLTIP);
         flip_button.clicked.disconnect (on_flip_horizontally);
         flip_button.clicked.connect (on_flip_vertically);
@@ -1617,14 +1615,13 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected override bool on_ctrl_released (Gdk.EventKey? event) {
-        rotate_button.set_icon_widget (new Gtk.Image.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR));
+        rotate_button.image = new Gtk.Image.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR);
         rotate_button.set_tooltip_text (Resources.ROTATE_CW_TOOLTIP);
         rotate_button.show_all ();
         rotate_button.clicked.disconnect (on_rotate_counterclockwise);
         rotate_button.clicked.connect (on_rotate_clockwise);
 
-        flip_button.set_icon_name (Resources.HFLIP);
-        flip_button.set_label (Resources.HFLIP_LABEL);
+        flip_button.image = new Gtk.Image.from_icon_name (Resources.HFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.set_tooltip_text (Resources.HFLIP_TOOLTIP);
         flip_button.clicked.disconnect (on_flip_vertically);
         flip_button.clicked.connect (on_flip_horizontally);
@@ -1635,7 +1632,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
         return base.on_ctrl_released (event);
     }
 
-    protected void on_tool_button_toggled (Gtk.ToggleToolButton toggle, EditingTools.EditingTool.Factory factory) {
+    protected void on_tool_button_toggled (Gtk.ToggleButton toggle, EditingTools.EditingTool.Factory factory) {
         // if the button is an activate, deactivate any current tool running; if the button is
         // a deactivate, deactivate the current tool and exit
         bool deactivating_only = (!toggle.active && current_editing_toggle == toggle);

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -99,115 +99,111 @@ public abstract class EditingHostPage : SinglePhotoPage {
         toolbar = get_toolbar ();
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            // set up page's toolbar (used by AppWindow for layout and FullscreenWindow as a popup)
+    protected override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        rotate_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR), _("Rotate"));
+        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
+        rotate_button.clicked.connect (on_rotate_clockwise);
 
-            rotate_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR), _("Rotate"));
-            rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
-            rotate_button.clicked.connect (on_rotate_clockwise);
+        flip_button = new Gtk.ToolButton (null, null);
+        flip_button.icon_name = "object-flip-horizontal";
+        flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
+        flip_button.clicked.connect (on_flip_horizontally);
 
-            flip_button = new Gtk.ToolButton (null, null);
-            flip_button.icon_name = "object-flip-horizontal";
-            flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
-            flip_button.clicked.connect (on_flip_horizontally);
+        crop_button = new Gtk.ToggleToolButton ();
+        crop_button.icon_widget = new Gtk.Image.from_icon_name ("image-crop", Gtk.IconSize.LARGE_TOOLBAR);
+        crop_button.tooltip_text = Resources.CROP_TOOLTIP;
+        crop_button.toggled.connect (on_crop_toggled);
 
-            crop_button = new Gtk.ToggleToolButton ();
-            crop_button.icon_widget = new Gtk.Image.from_icon_name ("image-crop", Gtk.IconSize.LARGE_TOOLBAR);
-            crop_button.tooltip_text = Resources.CROP_TOOLTIP;
-            crop_button.toggled.connect (on_crop_toggled);
+        straighten_button = new Gtk.ToggleToolButton ();
+        straighten_button.icon_widget = new Gtk.Image.from_icon_name ("object-straighten", Gtk.IconSize.LARGE_TOOLBAR);
+        straighten_button.tooltip_text = Resources.STRAIGHTEN_TOOLTIP;
+        straighten_button.toggled.connect (on_straighten_toggled);
 
-            straighten_button = new Gtk.ToggleToolButton ();
-            straighten_button.icon_widget = new Gtk.Image.from_icon_name ("object-straighten", Gtk.IconSize.LARGE_TOOLBAR);
-            straighten_button.tooltip_text = Resources.STRAIGHTEN_TOOLTIP;
-            straighten_button.toggled.connect (on_straighten_toggled);
+        redeye_button = new Gtk.ToggleToolButton ();
+        redeye_button.icon_widget = new Gtk.Image.from_icon_name ("image-red-eye", Gtk.IconSize.LARGE_TOOLBAR);
+        redeye_button.tooltip_text = Resources.RED_EYE_TOOLTIP;
+        redeye_button.toggled.connect (on_redeye_toggled);
 
-            redeye_button = new Gtk.ToggleToolButton ();
-            redeye_button.icon_widget = new Gtk.Image.from_icon_name ("image-red-eye", Gtk.IconSize.LARGE_TOOLBAR);
-            redeye_button.tooltip_text = Resources.RED_EYE_TOOLTIP;
-            redeye_button.toggled.connect (on_redeye_toggled);
+        adjust_button = new Gtk.ToggleToolButton ();
+        adjust_button.icon_widget = new Gtk.Image.from_icon_name ("image-adjust", Gtk.IconSize.LARGE_TOOLBAR);
+        adjust_button.tooltip_text = Resources.ADJUST_TOOLTIP;
+        adjust_button.toggled.connect (on_adjust_toggled);
 
-            adjust_button = new Gtk.ToggleToolButton ();
-            adjust_button.icon_widget = new Gtk.Image.from_icon_name ("image-adjust", Gtk.IconSize.LARGE_TOOLBAR);
-            adjust_button.tooltip_text = Resources.ADJUST_TOOLTIP;
-            adjust_button.toggled.connect (on_adjust_toggled);
+        enhance_button = new Gtk.ToggleToolButton ();
+        enhance_button.icon_widget = new Gtk.Image.from_icon_name ("image-auto-adjust", Gtk.IconSize.LARGE_TOOLBAR);
+        enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
+        enhance_button.clicked.connect (on_enhance);
 
-            enhance_button = new Gtk.ToggleToolButton ();
-            enhance_button.icon_widget = new Gtk.Image.from_icon_name ("image-auto-adjust", Gtk.IconSize.LARGE_TOOLBAR);
-            enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
-            enhance_button.clicked.connect (on_enhance);
+        var separator = new Gtk.SeparatorToolItem ();
+        separator.set_expand (true);
 
-            var separator = new Gtk.SeparatorToolItem ();
-            separator.set_expand (true);
+        var zoom_fit = new Gtk.Button.from_icon_name ("zoom-fit-best-symbolic", Gtk.IconSize.MENU);
+        zoom_fit.tooltip_text = _("Zoom to fit page");
+        zoom_fit.valign = Gtk.Align.CENTER;
+        zoom_fit.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-            var zoom_fit = new Gtk.Button.from_icon_name ("zoom-fit-best-symbolic", Gtk.IconSize.MENU);
-            zoom_fit.tooltip_text = _("Zoom to fit page");
-            zoom_fit.valign = Gtk.Align.CENTER;
-            zoom_fit.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        var zoom_fit_action = get_action ("ZoomFit");
+        zoom_fit_action.bind_property ("sensitive", zoom_fit, "sensitive", BindingFlags.SYNC_CREATE);
+        zoom_fit.clicked.connect (() => zoom_fit_action.activate ());
 
-            var zoom_fit_action = get_action ("ZoomFit");
-            zoom_fit_action.bind_property ("sensitive", zoom_fit, "sensitive", BindingFlags.SYNC_CREATE);
-            zoom_fit.clicked.connect (() => zoom_fit_action.activate ());
+        var zoom_original = new Gtk.Button.from_icon_name ("zoom-original-symbolic", Gtk.IconSize.MENU);
+        zoom_original.tooltip_text = _("Zoom 1:1");
+        zoom_original.valign = Gtk.Align.CENTER;
+        zoom_original.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        zoom_original.clicked.connect (() => {
+            snap_zoom_to_isomorphic ();
+        });
 
-            var zoom_original = new Gtk.Button.from_icon_name ("zoom-original-symbolic", Gtk.IconSize.MENU);
-            zoom_original.tooltip_text = _("Zoom 1:1");
-            zoom_original.valign = Gtk.Align.CENTER;
-            zoom_original.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-            zoom_original.clicked.connect (() => {
-                snap_zoom_to_isomorphic ();
-            });
+        zoom_slider = new SliderAssembly (0, 1.1, 0.1, 0);
+        zoom_slider.value_changed.connect (on_zoom_slider_value_changed);
 
-            zoom_slider = new SliderAssembly (0, 1.1, 0.1, 0);
-            zoom_slider.value_changed.connect (on_zoom_slider_value_changed);
+        var zoom_group = new Gtk.Grid ();
+        zoom_group.column_spacing = 6;
+        zoom_group.add (zoom_fit);
+        zoom_group.add (zoom_original);
+        zoom_group.add (zoom_slider);
 
-            var zoom_group = new Gtk.Grid ();
-            zoom_group.column_spacing = 6;
-            zoom_group.add (zoom_fit);
-            zoom_group.add (zoom_original);
-            zoom_group.add (zoom_slider);
+        var group_wrapper = new Gtk.ToolItem ();
+        group_wrapper.add (zoom_group);
 
-            var group_wrapper = new Gtk.ToolItem ();
-            group_wrapper.add (zoom_group);
+        prev_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
+        prev_button.tooltip_text = _("Previous photo");
+        prev_button.clicked.connect (on_previous_photo);
 
-            prev_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
-            prev_button.tooltip_text = _("Previous photo");
-            prev_button.clicked.connect (on_previous_photo);
+        next_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
+        next_button.tooltip_text = _("Next photo");
+        next_button.clicked.connect (on_next_photo);
 
-            next_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
-            next_button.tooltip_text = _("Next photo");
-            next_button.clicked.connect (on_next_photo);
+        // toolbar = base.get_toolbar ();
 
-            toolbar = base.get_toolbar ();
-            toolbar.pack_start (prev_button);
-            toolbar.pack_start (next_button);
-            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-            toolbar.pack_start (rotate_button);
-            toolbar.pack_start (flip_button);
-            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-            toolbar.pack_start (crop_button);
-            toolbar.pack_start (straighten_button);
-            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-            toolbar.pack_start (redeye_button);
-            toolbar.pack_start (adjust_button);
-            toolbar.pack_start (enhance_button);
+        toolbar.pack_start (prev_button);
+        toolbar.pack_start (next_button);
+        toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_start (rotate_button);
+        toolbar.pack_start (flip_button);
+        toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_start (crop_button);
+        toolbar.pack_start (straighten_button);
+        toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_start (redeye_button);
+        toolbar.pack_start (adjust_button);
+        toolbar.pack_start (enhance_button);
+        toolbar.pack_end (group_wrapper);
 
-            //  show metadata sidebar button
-            var app = AppWindow.get_instance () as LibraryWindow;
-            if (app != null) {
-                show_sidebar_button = MediaPage.create_sidebar_button ();
-                show_sidebar_button.clicked.connect (() => {
-                    app.set_metadata_sidebar_visible (!app.is_metadata_sidebar_visible ());
-                    update_sidebar_action (!app.is_metadata_sidebar_visible ());
-                });
-                toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-                toolbar.pack_end (show_sidebar_button);
+        //  show metadata sidebar button
+        var app = AppWindow.get_instance () as LibraryWindow;
+        if (app != null) {
+            show_sidebar_button = MediaPage.create_sidebar_button ();
+            show_sidebar_button.clicked.connect (() => {
+                app.set_metadata_sidebar_visible (!app.is_metadata_sidebar_visible ());
                 update_sidebar_action (!app.is_metadata_sidebar_visible ());
-            }
-
-            toolbar.pack_end (group_wrapper);
+            });
+            toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+            toolbar.pack_end (show_sidebar_button);
+            update_sidebar_action (!app.is_metadata_sidebar_visible ());
         }
 
-        return toolbar;
+        base.add_toolbar_widgets (toolbar);
     }
 
     ~EditingHostPage () {

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -133,9 +133,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
         enhance_button.tooltip_text = Resources.ENHANCE_TOOLTIP;
         enhance_button.clicked.connect (on_enhance);
 
-        // var separator = new Gtk.SeparatorToolItem ();
-        // separator.set_expand (true);
-
         var zoom_fit = new Gtk.Button.from_icon_name ("zoom-fit-best-symbolic", Gtk.IconSize.MENU);
         zoom_fit.tooltip_text = _("Zoom to fit page");
         zoom_fit.valign = Gtk.Align.CENTER;
@@ -172,8 +169,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
         next_button = new Gtk.Button.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         next_button.tooltip_text = _("Next photo");
         next_button.clicked.connect (on_next_photo);
-
-        // toolbar = base.get_toolbar ();
 
         toolbar.pack_start (prev_button);
         toolbar.pack_start (next_button);

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -180,10 +180,13 @@ public abstract class EditingHostPage : SinglePhotoPage {
             toolbar = base.get_toolbar ();
             toolbar.pack_start (prev_button);
             toolbar.pack_start (next_button);
+            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
             toolbar.pack_start (rotate_button);
             toolbar.pack_start (flip_button);
+            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
             toolbar.pack_start (crop_button);
             toolbar.pack_start (straighten_button);
+            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
             toolbar.pack_start (redeye_button);
             toolbar.pack_start (adjust_button);
             toolbar.pack_start (enhance_button);
@@ -196,6 +199,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
                     app.set_metadata_sidebar_visible (!app.is_metadata_sidebar_visible ());
                     update_sidebar_action (!app.is_metadata_sidebar_visible ());
                 });
+                toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
                 toolbar.pack_end (show_sidebar_button);
                 update_sidebar_action (!app.is_metadata_sidebar_visible ());
             }

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -99,7 +99,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
         toolbar = get_toolbar ();
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
             // set up page's toolbar (used by AppWindow for layout and FullscreenWindow as a popup)
 
@@ -178,20 +178,15 @@ public abstract class EditingHostPage : SinglePhotoPage {
             next_button.clicked.connect (on_next_photo);
 
             toolbar = base.get_toolbar ();
-            toolbar.add (prev_button);
-            toolbar.add (next_button);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (rotate_button);
-            toolbar.add (flip_button);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (crop_button);
-            toolbar.add (straighten_button);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (redeye_button);
-            toolbar.add (adjust_button);
-            toolbar.add (enhance_button);
-            toolbar.add (separator);
-            toolbar.add (group_wrapper);
+            toolbar.pack_start (prev_button);
+            toolbar.pack_start (next_button);
+            toolbar.pack_start (rotate_button);
+            toolbar.pack_start (flip_button);
+            toolbar.pack_start (crop_button);
+            toolbar.pack_start (straighten_button);
+            toolbar.pack_start (redeye_button);
+            toolbar.pack_start (adjust_button);
+            toolbar.pack_start (enhance_button);
 
             //  show metadata sidebar button
             var app = AppWindow.get_instance () as LibraryWindow;
@@ -201,9 +196,11 @@ public abstract class EditingHostPage : SinglePhotoPage {
                     app.set_metadata_sidebar_visible (!app.is_metadata_sidebar_visible ());
                     update_sidebar_action (!app.is_metadata_sidebar_visible ());
                 });
-                toolbar.add (show_sidebar_button);
+                toolbar.pack_end (show_sidebar_button);
                 update_sidebar_action (!app.is_metadata_sidebar_visible ());
             }
+
+            toolbar.pack_end (group_wrapper);
         }
 
         return toolbar;

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -57,12 +57,12 @@ public abstract class EditingHostPage : SinglePhotoPage {
     private Gtk.ToggleButton? redeye_button = null;
     private Gtk.ToggleButton? adjust_button = null;
     private Gtk.ToggleButton? straighten_button = null;
-    protected Gtk.ToggleButton enhance_button = null;
+    protected Gtk.ToggleButton? enhance_button = null;
     private SliderAssembly zoom_slider = null;
     private Gtk.Button prev_button = null;
     private Gtk.Button next_button = null;
     private EditingTools.EditingTool current_tool = null;
-    private Gtk.ToggleButton current_editing_toggle = null;
+    private Gtk.ToggleButton? current_editing_toggle = null;
     private Gdk.Pixbuf cancel_editing_pixbuf = null;
     private bool photo_missing = false;
     private PixbufCache cache = null;

--- a/src/Views/EventsDirectoryPage.vala
+++ b/src/Views/EventsDirectoryPage.vala
@@ -73,9 +73,9 @@ public abstract class EventsDirectoryPage : CheckerboardPage {
         show_sidebar_button.clicked.connect (on_show_sidebar);
 
         var toolbar = get_toolbar ();
-        toolbar.add (merge_button);
-        toolbar.add (separator);
-        toolbar.add (show_sidebar_button);
+        toolbar.pack_start (merge_button);
+        // toolbar.add (separator);
+        toolbar.pack_end (show_sidebar_button);
     }
 
     protected EventsDirectoryPage (string page_name, ViewManager view_manager,

--- a/src/Views/EventsDirectoryPage.vala
+++ b/src/Views/EventsDirectoryPage.vala
@@ -61,20 +61,15 @@ public abstract class EventsDirectoryPage : CheckerboardPage {
     construct {
         ui_settings = new GLib.Settings (GSettingsConfigurationEngine.UI_PREFS_SCHEMA_NAME);
 
-        var merge_button = new Gtk.ToolButton (null, null);
-        merge_button.icon_widget = new Gtk.Image.from_icon_name (Resources.MERGE, Gtk.IconSize.LARGE_TOOLBAR);
+        var merge_button = new Gtk.Button.from_icon_name (Resources.MERGE, Gtk.IconSize.LARGE_TOOLBAR);
         merge_button.related_action = get_action ("Merge");
         merge_button.tooltip_text = _("Merge events");
-
-        var separator = new Gtk.SeparatorToolItem ();
-        separator.set_expand (true);
 
         show_sidebar_button = MediaPage.create_sidebar_button ();
         show_sidebar_button.clicked.connect (on_show_sidebar);
 
         var toolbar = get_toolbar ();
         toolbar.pack_start (merge_button);
-        // toolbar.add (separator);
         toolbar.pack_end (show_sidebar_button);
     }
 

--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -779,56 +779,51 @@ public class ImportPage : CheckerboardPage {
         Video.global.contents_altered.disconnect (on_media_added_removed);
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            hide_imported = new Gtk.CheckButton.with_label (_("Hide photos already imported"));
-            hide_imported.active = ui_settings.get_boolean ("hide-photos-already-imported");
-            hide_imported.sensitive = false;
-            hide_imported.tooltip_text = _("Only display photos that have not been imported");
-            hide_imported.clicked.connect (on_hide_imported);
+    public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        hide_imported = new Gtk.CheckButton.with_label (_("Hide photos already imported"));
+        hide_imported.active = ui_settings.get_boolean ("hide-photos-already-imported");
+        hide_imported.sensitive = false;
+        hide_imported.tooltip_text = _("Only display photos that have not been imported");
+        hide_imported.clicked.connect (on_hide_imported);
 
-            var hide_item = new Gtk.ToolItem ();
-            hide_item.add (hide_imported);
+        var hide_item = new Gtk.ToolItem ();
+        hide_item.add (hide_imported);
 
-            var separator = new Gtk.SeparatorToolItem ();
-            separator.set_draw (false);
+        var separator = new Gtk.SeparatorToolItem ();
+        separator.set_draw (false);
 
-            progress_bar.orientation = Gtk.Orientation.HORIZONTAL;
-            progress_bar.visible = false;
-            progress_bar.show_text = true;
-            progress_bar.no_show_all = true;
+        progress_bar.orientation = Gtk.Orientation.HORIZONTAL;
+        progress_bar.visible = false;
+        progress_bar.show_text = true;
+        progress_bar.no_show_all = true;
 
-            var progress_item = new Gtk.ToolItem ();
-            progress_item.set_expand (true);
-            progress_item.add (progress_bar);
+        var progress_item = new Gtk.ToolItem ();
+        progress_item.set_expand (true);
+        progress_item.add (progress_bar);
 
-            var import_selected_button = new Gtk.Button.with_label ("Import Selected");
-            import_selected_button.set_related_action (get_action ("ImportSelected"));
+        var import_selected_button = new Gtk.Button.with_label ("Import Selected");
+        import_selected_button.set_related_action (get_action ("ImportSelected"));
 
-            var import_sel_ti = new Gtk.ToolItem ();
-            import_sel_ti.add (import_selected_button);
+        var import_sel_ti = new Gtk.ToolItem ();
+        import_sel_ti.add (import_selected_button);
 
-            var import_all_button = new Gtk.Button.with_label ("Import All");
-            import_all_button.set_related_action (get_action ("ImportAll"));
+        var import_all_button = new Gtk.Button.with_label ("Import All");
+        import_all_button.set_related_action (get_action ("ImportAll"));
 
-            var import_all_ti = new Gtk.ToolItem ();
-            import_all_ti.margin_start = 6;
-            import_all_ti.add (import_all_button);
+        var import_all_ti = new Gtk.ToolItem ();
+        import_all_ti.margin_start = 6;
+        import_all_ti.add (import_all_button);
 
-            base.get_toolbar ();
-            toolbar.pack_start (hide_item);
-            toolbar.pack_start (separator);
-            toolbar.pack_start (progress_item);
-            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-            toolbar.pack_start (import_sel_ti);
-            toolbar.pack_start (import_all_ti);
+        toolbar.pack_start (hide_item);
+        toolbar.pack_start (separator);
+        toolbar.pack_start (progress_item);
+        toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_start (import_sel_ti);
+        toolbar.pack_start (import_all_ti);
 
-            update_toolbar_state ();
+        update_toolbar_state ();
 
-            show_all ();
-        }
-
-        return toolbar;
+        base.add_toolbar_widgets (toolbar);
     }
 
     public override Gtk.Menu? get_item_context_menu () {

--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -779,7 +779,7 @@ public class ImportPage : CheckerboardPage {
         Video.global.contents_altered.disconnect (on_media_added_removed);
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
             hide_imported = new Gtk.CheckButton.with_label (_("Hide photos already imported"));
             hide_imported.active = ui_settings.get_boolean ("hide-photos-already-imported");

--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -816,12 +816,12 @@ public class ImportPage : CheckerboardPage {
             import_all_ti.add (import_all_button);
 
             base.get_toolbar ();
-            toolbar.add (hide_item);
-            toolbar.add (separator);
-            toolbar.add (progress_item);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (import_sel_ti);
-            toolbar.add (import_all_ti);
+            toolbar.pack_start (hide_item);
+            toolbar.pack_start (separator);
+            toolbar.pack_start (progress_item);
+            toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+            toolbar.pack_start (import_sel_ti);
+            toolbar.pack_start (import_all_ti);
 
             update_toolbar_state ();
 

--- a/src/Views/ImportQueuePage.vala
+++ b/src/Views/ImportQueuePage.vala
@@ -38,7 +38,7 @@ public class ImportQueuePage : SinglePhotoPage {
 
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
             var progress_item = new Gtk.ToolItem ();
             progress_item.set_expand (true);

--- a/src/Views/ImportQueuePage.vala
+++ b/src/Views/ImportQueuePage.vala
@@ -38,24 +38,20 @@ public class ImportQueuePage : SinglePhotoPage {
 
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            var progress_item = new Gtk.ToolItem ();
-            progress_item.set_expand (true);
-            progress_item.add (progress_bar);
+    public virtual void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        var progress_item = new Gtk.ToolItem ();
+        progress_item.set_expand (true);
+        progress_item.add (progress_bar);
 
-            progress_bar.set_show_text (true);
+        progress_bar.set_show_text (true);
 
-            var stop_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("process-stop-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
-            stop_button.set_related_action (get_action ("Stop"));
+        var stop_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("process-stop-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
+        stop_button.set_related_action (get_action ("Stop"));
 
-            toolbar = base.get_toolbar ();
-            toolbar.pack_start (progress_item);
-            toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-            toolbar.pack_end (stop_button);
-        }
-
-        return toolbar;
+        toolbar.pack_start (progress_item);
+        toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_end (stop_button);
+        base.add_toolbar_widgets (toolbar);
     }
 
     protected override Gtk.ActionEntry[] init_collect_action_entries () {

--- a/src/Views/ImportQueuePage.vala
+++ b/src/Views/ImportQueuePage.vala
@@ -45,11 +45,10 @@ public class ImportQueuePage : SinglePhotoPage {
 
         progress_bar.set_show_text (true);
 
-        var stop_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("process-stop-symbolic", Gtk.IconSize.LARGE_TOOLBAR), null);
+        var stop_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         stop_button.set_related_action (get_action ("Stop"));
 
         toolbar.pack_start (progress_item);
-        toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         toolbar.pack_end (stop_button);
         base.add_toolbar_widgets (toolbar);
     }

--- a/src/Views/ImportQueuePage.vala
+++ b/src/Views/ImportQueuePage.vala
@@ -50,9 +50,9 @@ public class ImportQueuePage : SinglePhotoPage {
             stop_button.set_related_action (get_action ("Stop"));
 
             toolbar = base.get_toolbar ();
-            toolbar.add (progress_item);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (stop_button);
+            toolbar.pack_start (progress_item);
+            toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+            toolbar.pack_end (stop_button);
         }
 
         return toolbar;

--- a/src/Views/LibraryPhotoPage.vala
+++ b/src/Views/LibraryPhotoPage.vala
@@ -55,10 +55,8 @@ public class LibraryPhotoPage : EditingHostPage {
     }
 
     public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
-        Gtk.Image start_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic",
-                                                              Gtk.IconSize.LARGE_TOOLBAR);
-
-        Gtk.ToolButton slideshow_button = new Gtk.ToolButton (start_image, _("S_lideshow"));
+        Gtk.Button slideshow_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic",
+                                                                     Gtk.IconSize.LARGE_TOOLBAR);
         slideshow_button.set_tooltip_text (_("Play a slideshow"));
         slideshow_button.clicked.connect (on_slideshow);
         toolbar.pack_start (slideshow_button);

--- a/src/Views/LibraryPhotoPage.vala
+++ b/src/Views/LibraryPhotoPage.vala
@@ -55,7 +55,7 @@ public class LibraryPhotoPage : EditingHostPage {
         LibraryPhoto.global.items_altered.disconnect (on_metadata_altered);
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
             base.get_toolbar ();
 
@@ -63,7 +63,7 @@ public class LibraryPhotoPage : EditingHostPage {
             Gtk.ToolButton slideshow_button = new Gtk.ToolButton (start_image, _("S_lideshow"));
             slideshow_button.set_tooltip_text (_("Play a slideshow"));
             slideshow_button.clicked.connect (on_slideshow);
-            get_toolbar ().insert (slideshow_button, 0);
+            get_toolbar ().pack_start (slideshow_button);
         }
         return toolbar;
     }

--- a/src/Views/LibraryPhotoPage.vala
+++ b/src/Views/LibraryPhotoPage.vala
@@ -36,7 +36,6 @@ public class LibraryPhotoPage : EditingHostPage {
 
     public LibraryPhotoPage () {
         base (LibraryPhoto.global, "Photo");
-
         // monitor view to update UI elements
         get_view ().items_altered.connect (on_photos_altered);
 
@@ -55,17 +54,15 @@ public class LibraryPhotoPage : EditingHostPage {
         LibraryPhoto.global.items_altered.disconnect (on_metadata_altered);
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            base.get_toolbar ();
+    public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        Gtk.Image start_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic",
+                                                              Gtk.IconSize.LARGE_TOOLBAR);
 
-            Gtk.Image start_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-            Gtk.ToolButton slideshow_button = new Gtk.ToolButton (start_image, _("S_lideshow"));
-            slideshow_button.set_tooltip_text (_("Play a slideshow"));
-            slideshow_button.clicked.connect (on_slideshow);
-            get_toolbar ().pack_start (slideshow_button);
-        }
-        return toolbar;
+        Gtk.ToolButton slideshow_button = new Gtk.ToolButton (start_image, _("S_lideshow"));
+        slideshow_button.set_tooltip_text (_("Play a slideshow"));
+        slideshow_button.clicked.connect (on_slideshow);
+        toolbar.pack_start (slideshow_button);
+        base.add_toolbar_widgets (toolbar);
     }
 
     public override Gtk.Box get_header_buttons () {

--- a/src/Views/MediaPage.vala
+++ b/src/Views/MediaPage.vala
@@ -802,9 +802,8 @@ public abstract class MediaPage : CheckerboardPage {
         return get_checkerboard_layout ().get_scale ();
     }
 
-    public static Gtk.ToolButton create_sidebar_button () {
-        var show_sidebar_button = new Gtk.ToolButton (null, null);
-        show_sidebar_button.icon_name = Resources.SHOW_PANE;
+    public static Gtk.Button create_sidebar_button () {
+        var show_sidebar_button = new Gtk.Button.from_icon_name (Resources.SHOW_PANE, Gtk.IconSize.LARGE_TOOLBAR);
         show_sidebar_button.tooltip_text = Resources.TOGGLE_METAPANE_TOOLTIP;
         return show_sidebar_button;
     }

--- a/src/Views/OfflinePage.vala
+++ b/src/Views/OfflinePage.vala
@@ -58,23 +58,17 @@ public class OfflinePage : CheckerboardPage {
         Video.global.offline_contents_altered.disconnect (on_offline_contents_altered);
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            toolbar = new Gtk.ActionBar ();
-            toolbar.get_style_context ().add_class ("bottom-toolbar"); // for elementary theme
-
-            var remove_button = new Gtk.Button.with_mnemonic (Resources.REMOVE_FROM_LIBRARY_MENU);
-            remove_button.margin_start = remove_button.margin_end = 3;
-            remove_button.tooltip_text = Resources.DELETE_FROM_LIBRARY_TOOLTIP;
-            var remove_tool = new Gtk.ToolItem ();
-            remove_tool.add (remove_button);
-            toolbar.pack_start (remove_tool);
-            var remove_action = get_action ("RemoveFromLibrary");
-            remove_action.bind_property ("sensitive", remove_button, "sensitive", BindingFlags.SYNC_CREATE);
-            remove_button.clicked.connect (() => remove_action.activate ());
-        }
-
-        return toolbar;
+    public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        var remove_button = new Gtk.Button.with_mnemonic (Resources.REMOVE_FROM_LIBRARY_MENU);
+        remove_button.margin_start = remove_button.margin_end = 3;
+        remove_button.tooltip_text = Resources.DELETE_FROM_LIBRARY_TOOLTIP;
+        var remove_tool = new Gtk.ToolItem ();
+        remove_tool.add (remove_button);
+        toolbar.pack_start (remove_tool);
+        var remove_action = get_action ("RemoveFromLibrary");
+        remove_action.bind_property ("sensitive", remove_button, "sensitive", BindingFlags.SYNC_CREATE);
+        remove_button.clicked.connect (() => remove_action.activate ());
+        base.add_toolbar_widgets (toolbar);
     }
 
     public override Gtk.Menu? get_page_sidebar_menu () {

--- a/src/Views/OfflinePage.vala
+++ b/src/Views/OfflinePage.vala
@@ -58,18 +58,17 @@ public class OfflinePage : CheckerboardPage {
         Video.global.offline_contents_altered.disconnect (on_offline_contents_altered);
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
-            toolbar = new Gtk.Toolbar ();
+            toolbar = new Gtk.ActionBar ();
             toolbar.get_style_context ().add_class ("bottom-toolbar"); // for elementary theme
-            toolbar.set_style (Gtk.ToolbarStyle.ICONS);
 
             var remove_button = new Gtk.Button.with_mnemonic (Resources.REMOVE_FROM_LIBRARY_MENU);
             remove_button.margin_start = remove_button.margin_end = 3;
             remove_button.tooltip_text = Resources.DELETE_FROM_LIBRARY_TOOLTIP;
             var remove_tool = new Gtk.ToolItem ();
             remove_tool.add (remove_button);
-            toolbar.insert (remove_tool, -1);
+            toolbar.pack_end (remove_tool);
             var remove_action = get_action ("RemoveFromLibrary");
             remove_action.bind_property ("sensitive", remove_button, "sensitive", BindingFlags.SYNC_CREATE);
             remove_button.clicked.connect (() => remove_action.activate ());

--- a/src/Views/OfflinePage.vala
+++ b/src/Views/OfflinePage.vala
@@ -68,7 +68,7 @@ public class OfflinePage : CheckerboardPage {
             remove_button.tooltip_text = Resources.DELETE_FROM_LIBRARY_TOOLTIP;
             var remove_tool = new Gtk.ToolItem ();
             remove_tool.add (remove_button);
-            toolbar.pack_end (remove_tool);
+            toolbar.pack_start (remove_tool);
             var remove_action = get_action ("RemoveFromLibrary");
             remove_action.bind_property ("sensitive", remove_button, "sensitive", BindingFlags.SYNC_CREATE);
             remove_button.clicked.connect (() => remove_action.activate ());

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -20,8 +20,8 @@
 public abstract class Page : Gtk.ScrolledWindow {
     private const int CONSIDER_CONFIGURE_HALTED_MSEC = 400;
 
-    protected Gtk.ActionBar toolbar;
-    protected Gtk.Button show_sidebar_button;
+    protected Gtk.ActionBar? toolbar = null;
+    protected Gtk.Button? show_sidebar_button = null;
 
     private ViewCollection view = null;
     private Gtk.Window container = null;

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -21,7 +21,7 @@ public abstract class Page : Gtk.ScrolledWindow {
     private const int CONSIDER_CONFIGURE_HALTED_MSEC = 400;
 
     protected Gtk.ActionBar toolbar;
-    protected Gtk.ToolButton show_sidebar_button;
+    protected Gtk.Button show_sidebar_button;
 
     private ViewCollection view = null;
     private Gtk.Window container = null;
@@ -319,10 +319,10 @@ public abstract class Page : Gtk.ScrolledWindow {
         if (show_sidebar_button == null)
             return;
         if (!show) {
-            show_sidebar_button.icon_name = Resources.HIDE_PANE;
+            show_sidebar_button.image = new Gtk.Image.from_icon_name (Resources.HIDE_PANE, Gtk.IconSize.LARGE_TOOLBAR);
             show_sidebar_button.tooltip_text = Resources.UNTOGGLE_METAPANE_TOOLTIP;
         } else {
-            show_sidebar_button.icon_name = Resources.SHOW_PANE;
+            show_sidebar_button.image = new Gtk.Image.from_icon_name (Resources.SHOW_PANE, Gtk.IconSize.LARGE_TOOLBAR);
             show_sidebar_button.tooltip_text = Resources.TOGGLE_METAPANE_TOOLTIP;
         }
         var app = AppWindow.get_instance () as LibraryWindow;

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -20,7 +20,7 @@
 public abstract class Page : Gtk.ScrolledWindow {
     private const int CONSIDER_CONFIGURE_HALTED_MSEC = 400;
 
-    protected Gtk.Toolbar toolbar;
+    protected Gtk.ActionBar toolbar;
     protected Gtk.ToolButton show_sidebar_button;
 
     private ViewCollection view = null;
@@ -206,11 +206,10 @@ public abstract class Page : Gtk.ScrolledWindow {
         return event_source;
     }
 
-    public virtual Gtk.Toolbar get_toolbar () {
+    public virtual Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
-            toolbar = new Gtk.Toolbar ();
+            toolbar = new Gtk.ActionBar ();
             toolbar.get_style_context ().add_class ("bottom-toolbar"); // for elementary theme
-            toolbar.set_style (Gtk.ToolbarStyle.ICONS);
             toolbar.valign = Gtk.Align.END;
             toolbar.halign = Gtk.Align.FILL;
         }

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -228,7 +228,7 @@ public abstract class Page : Gtk.ScrolledWindow {
                 toolbar.pack_end (add_widget);
             }
 
-            show_all ()
+            show_all ();
         }
 
         return toolbar;

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -206,14 +206,35 @@ public abstract class Page : Gtk.ScrolledWindow {
         return event_source;
     }
 
-    public virtual Gtk.ActionBar get_toolbar () {
+    /* Parameters add ability to have a widget inserted (by the parent) before or after the parents actionbar widgets
+     * Otherwise Any widgets packed into the actionbar after getting it from the parent will appear inside the 
+     * parent's widgets. */
+    public Gtk.ActionBar get_toolbar (Gtk.Widget? add_widget = null,
+                                      Gtk.PackType position = Gtk.PackType.START) {
+
         if (toolbar == null) {
             toolbar = new Gtk.ActionBar ();
             toolbar.get_style_context ().add_class ("bottom-toolbar"); // for elementary theme
             toolbar.valign = Gtk.Align.END;
             toolbar.halign = Gtk.Align.FILL;
+
+            if (add_widget != null && position == Gtk.PackType.START) {
+                toolbar.pack_start (add_widget);
+            }
+
+            add_toolbar_widgets (toolbar);
+
+            if (add_widget != null && position == Gtk.PackType.END) {
+                toolbar.pack_end (add_widget);
+            }
+
+            show_all ()
         }
+
         return toolbar;
+    }
+
+    protected virtual void add_toolbar_widgets (Gtk.ActionBar toolbar) {
     }
 
     public virtual Gtk.Menu? get_page_context_menu () {

--- a/src/Views/SlideshowPage.vala
+++ b/src/Views/SlideshowPage.vala
@@ -106,7 +106,7 @@ class SlideshowPage : SinglePhotoPage {
         slider_wrapper.margin_start = 6;
         slider_wrapper.add (slider);
 
-        var toolbar = get_toolbar ();
+        var toolbar = base.get_toolbar ();
         toolbar.pack_start (previous_button);
         toolbar.pack_start (play_pause_button);
         toolbar.pack_start (next_button);

--- a/src/Views/SlideshowPage.vala
+++ b/src/Views/SlideshowPage.vala
@@ -61,7 +61,7 @@ class SlideshowPage : SinglePhotoPage {
 
         update_transition_effect ();
 
-        var previous_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR), _("Back"));
+        var previous_button = new Gtk.Button.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         previous_button.tooltip_text = _("Go to the previous photo");
         previous_button.clicked.connect (on_previous_photo);
 

--- a/src/Views/SlideshowPage.vala
+++ b/src/Views/SlideshowPage.vala
@@ -23,7 +23,7 @@ class SlideshowPage : SinglePhotoPage {
     private const int CHECK_ADVANCE_MSEC = 250;
 
     private Photo current;
-    private Gtk.ToolButton play_pause_button;
+    private Gtk.Button play_pause_button;
     private PixbufCache cache = null;
     private Timer timer = new Timer ();
     private bool playing = true;
@@ -65,19 +65,19 @@ class SlideshowPage : SinglePhotoPage {
         previous_button.tooltip_text = _("Go to the previous photo");
         previous_button.clicked.connect (on_previous_photo);
 
-        play_pause_button = new Gtk.ToolButton (null, _("Pause"));
-        play_pause_button.icon_name = "media-playback-pause-symbolic";
+        play_pause_button = new Gtk.Button.from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         play_pause_button.tooltip_text = _("Pause the slideshow");
         play_pause_button.clicked.connect (on_play_pause);
 
-        var next_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR), _("Next"));
+        var next_button = new Gtk.Button.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         next_button.tooltip_text = _("Go to the next photo");
         next_button.clicked.connect (on_next_photo);
 
         var effect_selector = new TransitionEffectSelector ();
 
-        var titles_toggle = new Gtk.ToggleToolButton ();
-        titles_toggle.icon_name = "preferences-desktop-font-symbolic";
+        var titles_toggle = new Gtk.ToggleButton ();
+        titles_toggle.image = new Gtk.Image.from_icon_name ("preferences-desktop-font-symbolic",
+                                                            Gtk.IconSize.LARGE_TOOLBAR);
         titles_toggle.tooltip_text = _("Show Photo Titles");
         titles_toggle.margin_start = 6;
         titles_toggle.active = slideshow_settings.get_boolean ("show-title");
@@ -192,10 +192,12 @@ class SlideshowPage : SinglePhotoPage {
 
     private void on_play_pause () {
         if (playing) {
-            play_pause_button.icon_name = "media-playback-start-symbolic";
+            play_pause_button.image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic",
+                                                                    Gtk.IconSize.LARGE_TOOLBAR);
             play_pause_button.tooltip_text = _("Continue the slideshow");
         } else {
-            play_pause_button.icon_name = "media-playback-pause-symbolic";
+            play_pause_button.image = new Gtk.Image.from_icon_name ("media-playback-pause-symbolic",
+                                                                    Gtk.IconSize.LARGE_TOOLBAR);
             play_pause_button.tooltip_text = _("Pause the slideshow");
         }
 

--- a/src/Views/SlideshowPage.vala
+++ b/src/Views/SlideshowPage.vala
@@ -107,14 +107,14 @@ class SlideshowPage : SinglePhotoPage {
         slider_wrapper.add (slider);
 
         var toolbar = get_toolbar ();
-        toolbar.add (previous_button);
-        toolbar.add (play_pause_button);
-        toolbar.add (next_button);
-        toolbar.add (new Gtk.SeparatorToolItem ());
-        toolbar.add (effect_selector);
-        toolbar.add (titles_toggle);
-        toolbar.add (slider_wrapper);
-        toolbar.add (new Gtk.SeparatorToolItem ());
+        toolbar.pack_start (previous_button);
+        toolbar.pack_start (play_pause_button);
+        toolbar.pack_start (next_button);
+        toolbar.add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_start (effect_selector);
+        toolbar.pack_start (titles_toggle);
+        toolbar.pack_start (slider_wrapper);
+        toolbar.add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
     }
 
     public override void switched_to () {

--- a/src/Views/TagPage.vala
+++ b/src/Views/TagPage.vala
@@ -55,7 +55,7 @@ public class TagPage : CollectionPage {
             delete_menu_item.activate.connect (() => delete_action.activate ());
 
             page_sidebar_menu.add (new_child_menu_item);
-            page_sidebar_menu.add (new Gtk.SeparatorToolItem ());
+            page_sidebar_menu.add (new Gtk.SeparatorMenuItem ());
             page_sidebar_menu.add (rename_menu_item);
             page_sidebar_menu.add (delete_menu_item);
             page_sidebar_menu.show_all ();

--- a/src/Views/TrashPage.vala
+++ b/src/Views/TrashPage.vala
@@ -58,9 +58,9 @@ public class TrashPage : CheckerboardPage {
         if (toolbar == null) {
             var app = AppWindow.get_instance () as LibraryWindow;
 
-            var separator = new Gtk.SeparatorToolItem ();
-            separator.set_expand (true);
-            separator.set_draw (false);
+            // var separator = new Gtk.SeparatorToolItem ();
+            // separator.set_expand (true);
+            // separator.set_draw (false);
 
             var restore_button = new Gtk.Button.with_mnemonic (Resources.RESTORE_PHOTOS_MENU);
             restore_button.margin_start = restore_button.margin_end = 3;
@@ -100,12 +100,12 @@ public class TrashPage : CheckerboardPage {
             show_sidebar_button.clicked.connect (on_show_sidebar);
 
             base.get_toolbar ();
-            toolbar.add (separator);
-            toolbar.add (restore_tool);
-            toolbar.add (delete_tool);
-            toolbar.add (empty_trash_tool);
-            toolbar.add (new Gtk.SeparatorToolItem ());
-            toolbar.add (show_sidebar_button);
+            // toolbar.add (separator);
+            toolbar.pack_start (restore_tool);
+            toolbar.pack_start (delete_tool);
+            toolbar.pack_start (empty_trash_tool);
+            toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+            toolbar.pack_end (show_sidebar_button);
 
             update_sidebar_action (!app.is_metadata_sidebar_visible ());
         }

--- a/src/Views/TrashPage.vala
+++ b/src/Views/TrashPage.vala
@@ -54,62 +54,53 @@ public class TrashPage : CheckerboardPage {
         on_trashcan_contents_altered (Video.global.get_trashcan_contents (), null);
     }
 
-    public override Gtk.ActionBar get_toolbar () {
-        if (toolbar == null) {
-            var app = AppWindow.get_instance () as LibraryWindow;
+    public override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
+        var app = AppWindow.get_instance () as LibraryWindow;
 
-            // var separator = new Gtk.SeparatorToolItem ();
-            // separator.set_expand (true);
-            // separator.set_draw (false);
+        var restore_button = new Gtk.Button.with_mnemonic (Resources.RESTORE_PHOTOS_MENU);
+        restore_button.margin_start = restore_button.margin_end = 3;
+        restore_button.clicked.connect (on_restore);
+        restore_button.tooltip_text = Resources.RESTORE_PHOTOS_TOOLTIP;
 
-            var restore_button = new Gtk.Button.with_mnemonic (Resources.RESTORE_PHOTOS_MENU);
-            restore_button.margin_start = restore_button.margin_end = 3;
-            restore_button.clicked.connect (on_restore);
-            restore_button.tooltip_text = Resources.RESTORE_PHOTOS_TOOLTIP;
+        var restore_tool = new Gtk.ToolItem ();
+        restore_tool.add (restore_button);
 
-            var restore_tool = new Gtk.ToolItem ();
-            restore_tool.add (restore_button);
+        var restore_action = get_action ("Restore");
+        restore_action.bind_property ("sensitive", restore_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-            var restore_action = get_action ("Restore");
-            restore_action.bind_property ("sensitive", restore_button, "sensitive", BindingFlags.SYNC_CREATE);
+        var delete_button = new Gtk.Button.with_mnemonic (Resources.DELETE_PHOTOS_MENU);
+        delete_button.margin_start = delete_button.margin_end = 3;
+        delete_button.tooltip_text = Resources.DELETE_FROM_TRASH_TOOLTIP;
+        delete_button.clicked.connect (on_delete);
 
-            var delete_button = new Gtk.Button.with_mnemonic (Resources.DELETE_PHOTOS_MENU);
-            delete_button.margin_start = delete_button.margin_end = 3;
-            delete_button.tooltip_text = Resources.DELETE_FROM_TRASH_TOOLTIP;
-            delete_button.clicked.connect (on_delete);
+        var delete_tool = new Gtk.ToolItem ();
+        delete_tool.add (delete_button);
 
-            var delete_tool = new Gtk.ToolItem ();
-            delete_tool.add (delete_button);
+        var delete_action = get_action ("Delete");
+        delete_action.bind_property ("sensitive", delete_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-            var delete_action = get_action ("Delete");
-            delete_action.bind_property ("sensitive", delete_button, "sensitive", BindingFlags.SYNC_CREATE);
+        var empty_trash_button = new Gtk.Button.with_mnemonic (_("_Empty Trash"));
+        empty_trash_button.margin_start = empty_trash_button.margin_end = 3;
+        empty_trash_button.tooltip_text = _("Delete all photos in the trash");
+        empty_trash_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        empty_trash_button.clicked.connect (on_empty_trash);
 
-            var empty_trash_button = new Gtk.Button.with_mnemonic (_("_Empty Trash"));
-            empty_trash_button.margin_start = empty_trash_button.margin_end = 3;
-            empty_trash_button.tooltip_text = _("Delete all photos in the trash");
-            empty_trash_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-            empty_trash_button.clicked.connect (on_empty_trash);
+        var empty_trash_tool = new Gtk.ToolItem ();
+        empty_trash_tool.add (empty_trash_button);
 
-            var empty_trash_tool = new Gtk.ToolItem ();
-            empty_trash_tool.add (empty_trash_button);
+        var empty_trash_action = get_action ("EmptyTrash");
+        empty_trash_action.bind_property ("sensitive", empty_trash_button, "sensitive", BindingFlags.SYNC_CREATE);
 
-            var empty_trash_action = get_action ("EmptyTrash");
-            empty_trash_action.bind_property ("sensitive", empty_trash_button, "sensitive", BindingFlags.SYNC_CREATE);
+        show_sidebar_button = MediaPage.create_sidebar_button ();
+        show_sidebar_button.clicked.connect (on_show_sidebar);
+        toolbar.pack_start (restore_tool);
+        toolbar.pack_start (delete_tool);
+        toolbar.pack_start (empty_trash_tool);
+        toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        toolbar.pack_end (show_sidebar_button);
 
-            show_sidebar_button = MediaPage.create_sidebar_button ();
-            show_sidebar_button.clicked.connect (on_show_sidebar);
-
-            base.get_toolbar ();
-            // toolbar.add (separator);
-            toolbar.pack_start (restore_tool);
-            toolbar.pack_start (delete_tool);
-            toolbar.pack_start (empty_trash_tool);
-            toolbar.pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-            toolbar.pack_end (show_sidebar_button);
-
-            update_sidebar_action (!app.is_metadata_sidebar_visible ());
-        }
-        return toolbar;
+        update_sidebar_action (!app.is_metadata_sidebar_visible ());
+        base.add_toolbar_widgets (toolbar);
     }
 
     public override Gtk.Menu? get_item_context_menu () {

--- a/src/Views/TrashPage.vala
+++ b/src/Views/TrashPage.vala
@@ -54,7 +54,7 @@ public class TrashPage : CheckerboardPage {
         on_trashcan_contents_altered (Video.global.get_trashcan_contents (), null);
     }
 
-    public override Gtk.Toolbar get_toolbar () {
+    public override Gtk.ActionBar get_toolbar () {
         if (toolbar == null) {
             var app = AppWindow.get_instance () as LibraryWindow;
 

--- a/src/library/LibraryWindow.vala
+++ b/src/library/LibraryWindow.vala
@@ -1087,7 +1087,7 @@ public class LibraryWindow : AppWindow {
         metadata_sidebar.save_changes ();
         Page current_page = get_current_page ();
         if (current_page != null) {
-            Gtk.Toolbar toolbar = current_page.get_toolbar ();
+            Gtk.ActionBar toolbar = current_page.get_toolbar ();
             if (toolbar != null) {
                 toolbar.destroy ();
             }


### PR DESCRIPTION
Fixes #615 by replacing the future deprecated Gtk.Toolbar with Gtk.ActionBar

As ActionBar has no "insert at position" method some work will be required to maintain (approximately) the same appearance.

 - [x] First compilable version
 - [x] Replace `add` with `pack_start` and `pack_end` everywhere
 - [x] Replace `ToolXXX` widgets with standard widgets everywhere
 - [ ] Maintain appearance as far as possible everywhere (needs Design Team input)