### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ pluginsdir = join_paths(get_option('prefix'), get_option('libdir'), meson.projec
 conf_data = configuration_data()
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
 conf_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+conf_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 conf_data.set_quoted('_VERSION', meson.project_version())
 conf_data.set_quoted('_PREFIX', get_option('prefix'))
 conf_data.set_quoted('_LIB', join_paths(get_option('prefix'), get_option('libdir')))

--- a/src/main.vala
+++ b/src/main.vala
@@ -365,6 +365,8 @@ void main (string[] args) {
     // init internationalization with the default system locale
     Intl.setlocale (LocaleCategory.ALL, "");
     Intl.textdomain (GETTEXT_PACKAGE);
+    Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+    Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
     startup_timer = new Timer ();
     startup_timer.start ();

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -11,6 +11,8 @@ extern const string _VERSION;
 [CCode (cheader_filename="config.h")]
 extern const string GETTEXT_PACKAGE;
 [CCode (cheader_filename="config.h")]
+extern const string LOCALEDIR;
+[CCode (cheader_filename="config.h")]
 extern const string _LIB;
 [CCode (cheader_filename="config.h")]
 extern const string _LIBEXECDIR;


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)