### PR TITLE
Automatically focus photo on file open

### DIFF
--- a/src/direct/DirectWindow.vala
+++ b/src/direct/DirectWindow.vala
@@ -56,6 +56,9 @@ public class DirectWindow : AppWindow {
         header.pack_start (save_as_btn);
         header.pack_end (redo_btn);
         header.pack_end (undo_btn);
+
+        // Set initial focus on photo
+        direct_photo_page.focus(Gtk.DirectionType.DOWN);
     }
 
     construct {

--- a/src/direct/DirectWindow.vala
+++ b/src/direct/DirectWindow.vala
@@ -58,7 +58,7 @@ public class DirectWindow : AppWindow {
         header.pack_end (undo_btn);
 
         // Set initial focus on photo
-        direct_photo_page.focus(Gtk.DirectionType.DOWN);
+        direct_photo_page.focus (Gtk.DirectionType.DOWN);
     }
 
     construct {


### PR DESCRIPTION
Automatically focus photo on file open. This prevents the **"Save as"** button from getting the initial focus which prevented the left and right arrows on the keyboard from navigating to the previous an next photos respectively.

Fixes #600 

![fix](https://user-images.githubusercontent.com/5112985/134635964-2c270dc4-a091-4390-96af-e45a731a99ed.png)



