### PR TITLE
Update vapi files

### DIFF
--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -312,10 +312,8 @@ class ImportPreview : CheckerboardItem {
             pixbuf = icon_theme.load_icon ("image-missing", 48, 0);
         } catch (Error e) {
             // Create an empty black pixbuf as a fallback
-            pixbuf = new Gdk.Pixbuf (Gdk.Colorspace.RGB, false, 8, 50, 50);
+            pixbuf = new Gdk.Pixbuf (Gdk.Colorspace.RGB, false, 8, 48, 48);
             pixbuf.fill (0);
-
-            warning("Could not load icon from theme: %s", e.message);
         }
 
         return pixbuf;

--- a/src/camera/GPhoto.vala
+++ b/src/camera/GPhoto.vala
@@ -127,13 +127,24 @@ public bool get_info (Context context, Camera camera, string folder, string file
     return true;
 }
 
+public Bytes? camera_file_to_bytes (Context context, CameraFile file) {
+    // if buffer can be loaded into memory, return a Bytes class with
+    // CameraFile being the owner of the data. This way, the CameraFile is freed
+    // when the Bytes are freed
+    unowned uint8[] buffer = null;
+    var res = file.get_data(out buffer);
+    if (res != Result.OK)
+        return null;
+
+    return Bytes.new_with_owner<GPhoto.CameraFile>(buffer, file);
+}
+
 // Libgphoto will in some instances refuse to get metadata from a camera, but the camera is accessable as a
 // filesystem.  In these cases shotwell can access the file directly. See:
 // http://redmine.yorba.org/issues/2959
 public PhotoMetadata? get_fallback_metadata (Camera camera, Context context, string folder, string filename) {
-    GPhoto.CameraStorageInformation *sifs = null;
-    int count = 0;
-    camera.get_storageinfo (&sifs, out count, context);
+    GPhoto.CameraStorageInformation[] sifs = null;
+    camera.get_storageinfo (out sifs, context);
 
     GPhoto.PortInfo port_info;
     camera.get_port_info (out port_info);
@@ -158,9 +169,10 @@ public PhotoMetadata? get_fallback_metadata (Camera camera, Context context, str
 }
 
 public Gdk.Pixbuf? load_preview (Context context, Camera camera, string folder, string filename,
-                                 out uint8[] raw, out size_t raw_length) throws Error {
-    raw = null;
-    raw_length = 0;
+                                 out string? preview_md5) throws Error {
+    Bytes? raw = null;
+    Bytes? out_bytes = null;
+    preview_md5 = null;
 
     try {
         raw = load_file_into_buffer (context, camera, folder, filename, GPhoto.CameraFileType.PREVIEW);
@@ -170,34 +182,21 @@ public Gdk.Pixbuf? load_preview (Context context, Camera camera, string folder, 
             return null;
         if (0 == metadata.get_preview_count ())
             return null;
-        PhotoPreview? preview = metadata.get_preview (metadata.get_preview_count () - 1);
+
+        // Get the smallest preview from meta-data
+        var preview = metadata.get_preview (metadata.get_preview_count () - 1);
         raw = preview.flatten ();
+        preview_md5 = Checksum.compute_for_bytes (ChecksumType.MD5, raw);
     }
 
-    if (raw == null) {
-        raw_length = 0;
-        return null;
-    }
+    out_bytes = raw;
+    preview_md5 = Checksum.compute_for_bytes (ChecksumType.MD5, out_bytes);
 
-    raw_length = raw.length;
+    MemoryInputStream mins = new MemoryInputStream.from_bytes (raw);
 
-    // Try to make sure last two bytes are JPEG footer.
-    // This is necessary because GPhoto sometimes includes a few extra bytes. See
-    // Yorba bug #2905 and the following GPhoto bug:
-    // http://sourceforge.net/tracker/?func=detail&aid=3141521&group_id=8874&atid=108874
-    if (raw_length > 32) {
-        for (size_t i = raw_length - 2; i > raw_length - 32; i--) {
-            if (raw[i] == Jpeg.MARKER_PREFIX && raw[i + 1] == Jpeg.Marker.EOI) {
-                debug ("Adjusted length of thumbnail for: %s", filename);
-                raw_length = i + 2;
-                break;
-            }
-        }
-    }
-
-    MemoryInputStream mins = new MemoryInputStream.from_data (raw, null);
     return new Gdk.Pixbuf.from_stream_at_scale (mins, ImportPreview.MAX_SCALE, ImportPreview.MAX_SCALE, true, null);
 }
+
 
 public Gdk.Pixbuf? load_image (Context context, Camera camera, string folder, string filename)
 throws Error {
@@ -228,7 +227,7 @@ public void save_image (Context context, Camera camera, string folder, string fi
 
 public PhotoMetadata? load_metadata (Context context, Camera camera, string folder, string filename)
 throws Error {
-    uint8[] camera_raw = null;
+    Bytes? camera_raw = null;
     try {
         camera_raw = load_file_into_buffer (context, camera, folder, filename, GPhoto.CameraFileType.EXIF);
     } catch {
@@ -258,17 +257,12 @@ public InputStream load_file_into_stream (Context context, Camera camera, string
         throw new GPhotoError.LIBRARY ("[%d] Error retrieving file object for %s/%s: %s",
         (int) res, folder, filename, res.as_string ());
 
-    // if entire file fits in memory, return a stream from that ... can't merely wrap
-    // MemoryInputStream around the camera_file buffer, as that will be destroyed when the
-    // function returns
-    unowned uint8 *data;
-    ulong data_len;
-    res = camera_file.get_data_and_size (out data, out data_len);
-    if (res == Result.OK) {
-        uint8[] buffer = new uint8[data_len];
-        Memory.copy (buffer, data, buffer.length);
-
-        return new MemoryInputStream.from_data (buffer, on_mins_destroyed);
+    // if entire file fits in memory, return a stream from that ...
+    // The camera_file is set as data on the object to keep it alive while
+    // the MemoryInputStream is alive.
+    var bytes = camera_file_to_bytes (context, camera_file);
+    if (bytes != null) {
+        return new MemoryInputStream.from_bytes (bytes);
     }
 
     // if not stored in memory, try copying it to a temp file and then reading out of that
@@ -281,13 +275,9 @@ public InputStream load_file_into_stream (Context context, Camera camera, string
     return temp.read (null);
 }
 
-private static void on_mins_destroyed (void *data) {
-    free (data);
-}
-
 // Returns a buffer with the requested file, if within reason.  Use load_file for larger files.
-public uint8[]? load_file_into_buffer (Context context, Camera camera, string folder,
-                                       string filename, CameraFileType filetype) throws Error {
+public Bytes? load_file_into_buffer (Context context, Camera camera, string folder,
+                                     string filename, CameraFileType filetype) throws Error {
     GPhoto.CameraFile camera_file;
     GPhoto.Result res = GPhoto.CameraFile.create (out camera_file);
     if (res != Result.OK)
@@ -298,17 +288,6 @@ public uint8[]? load_file_into_buffer (Context context, Camera camera, string fo
         throw new GPhotoError.LIBRARY ("[%d] Error retrieving file object for %s/%s: %s",
         (int) res, folder, filename, res.as_string ());
 
-    // if buffer can be loaded into memory, return a copy of that (can't return buffer itself
-    // as it will be destroyed when the camera_file is unref'd)
-    unowned uint8 *data;
-    ulong data_len;
-    res = camera_file.get_data_and_size (out data, out data_len);
-    if (res != Result.OK)
-        return null;
-
-    uint8[] buffer = new uint8[data_len];
-    Memory.copy (buffer, data, buffer.length);
-
-    return buffer;
+    return camera_file_to_bytes (context, camera_file);
 }
 }

--- a/src/camera/GPhoto.vala
+++ b/src/camera/GPhoto.vala
@@ -132,11 +132,11 @@ public Bytes? camera_file_to_bytes (Context context, CameraFile file) {
     // CameraFile being the owner of the data. This way, the CameraFile is freed
     // when the Bytes are freed
     unowned uint8[] buffer = null;
-    var res = file.get_data(out buffer);
+    var res = file.get_data (out buffer);
     if (res != Result.OK)
         return null;
 
-    return Bytes.new_with_owner<GPhoto.CameraFile>(buffer, file);
+    return Bytes.new_with_owner<GPhoto.CameraFile> (buffer, file);
 }
 
 // Libgphoto will in some instances refuse to get metadata from a camera, but the camera is accessable as a

--- a/vapi/libexif.vapi
+++ b/vapi/libexif.vapi
@@ -1,4 +1,5 @@
 /* Copyright 2009-2013 Yorba Foundation
+ * Copyright 2016 Software Freedom Conservancy Inc.
  *
  * This software is licensed under the GNU LGPL (version 2.1 or later).
  * See the COPYING file in this distribution.
@@ -63,7 +64,11 @@ namespace Exif {
         public static void set_slong(uchar *buffer, ByteOrder byteOrder, int32 val);
     }
 
-    [CCode (cheader_filename="libexif/exif-content.h", has_target=false)]
+    [CCode (
+        cheader_filename="libexif/exif-content.h",
+        has_target=false,
+        cname="ExifContentForeachEntryFunc"
+    )]
     public delegate void ForeachEntryFunc(Entry e, void *user);
 
     [Compact]
@@ -79,7 +84,7 @@ namespace Exif {
         [CCode (cname="exif_data_new")]
         public Data();
         public static Data? new_from_file(string path);
-        public static Data? new_from_data(uint8 *data, size_t count);
+        public static Data? new_from_data([CCode (array_length_pos=1.1)]uint8[] data);
         public void dump();
         public void fix();
         public void foreach_content(ForeachContentFunc cb, void *user = null);
@@ -90,14 +95,18 @@ namespace Exif {
         public void unset_option(DataOption option);
         public void save_data(uchar **buffer, uint *size);
         public void set_data_type(DataType data_type);
-        
+
         // length is Exif.IFD_COUNT
-        public Content[] ifd;
+        public Content ifd[Exif.IFD_COUNT];
         public uchar *data;
         public uint size;
     }
 
-    [CCode (cheader_filename="libexif/exif-data.h", has_target=false)]
+    [CCode (
+        cheader_filename="libexif/exif-data.h",
+        has_target=false,
+        cname="ExifDataForeachContentFunc"
+    )]
     public delegate void ForeachContentFunc(Content c, void *user);
 
     [CCode (
@@ -113,7 +122,7 @@ namespace Exif {
         public unowned string get_name();
         public unowned string get_description();
     }
-    
+
     [CCode (
         cname="ExifDataType",
         cheader_filename="libexif/exif-data-type.h",
@@ -124,7 +133,7 @@ namespace Exif {
         UNCOMPRESSED_PLANAR,
         UNCOMPRESSED_YCC,
         COMPRESSED;
-        
+
         public bool is_valid() {
             switch (this) {
                 case UNCOMPRESSED_CHUNKY:
@@ -132,16 +141,16 @@ namespace Exif {
                 case UNCOMPRESSED_YCC:
                 case COMPRESSED:
                     return true;
-                
+
                 default:
                     return false;
             }
         }
     }
-    
+
     [CCode (cname="EXIF_DATA_TYPE_COUNT")]
     public const int DATA_TYPE_COUNT;
-    
+
     [Compact]
     [CCode (
         cname="ExifEntry",
@@ -160,14 +169,14 @@ namespace Exif {
         public string get_string() {
             char[] buffer = new char[256];
             get_value(buffer, 256);
-            
+
             GLib.StringBuilder builder = new GLib.StringBuilder();
             foreach (char c in buffer)
                 builder.append_c(c);
-            
+
             return builder.str;
         }
-        
+
         public Tag tag;
         public Format format;
         public ulong components;
@@ -215,7 +224,7 @@ namespace Exif {
 
         public unowned string get_name();
     }
-    
+
     [CCode (cname="EXIF_IFD_COUNT")]
     public const int IFD_COUNT;
 
@@ -265,7 +274,7 @@ namespace Exif {
         public unowned string get_title();
         public unowned string get_message();
     }
-    
+
     [Compact]
     [CCode (
         cname="ExifMem",
@@ -280,7 +289,7 @@ namespace Exif {
         public void free(void *ptr);
         public static Mem new_default();
     }
-    
+
     [SimpleType]
     [CCode (
         cname="ExifRational",
@@ -290,7 +299,7 @@ namespace Exif {
         uint32 numerator;
         uint32 denominator;
     }
-    
+
     [CCode (
         cname="ExifSupportLevel",
         cheader_filename="libexif/exif-tag.h",
@@ -302,7 +311,7 @@ namespace Exif {
         MANDATORY,
         OPTIONAL
     }
-    
+
     [CCode (
         cname="ExifTag",
         cheader_filename="libexif/exif-tag.h",
@@ -338,3 +347,4 @@ namespace Exif {
         public SupportLevel get_support_level_in_ifd(Ifd ifd, DataType data_type);
     }
 }
+


### PR DESCRIPTION
Fixes #638 

Copied in the changes from the Shotwell vapi files and fixed up and tested the associated vala.

All of these code changes relate to importing and previewing files from a camera which I've just tested still works with my Pixel 4a.

I also changed how the `image-missing` icon is loaded in the import page as this was not working and causing criticals in the terminal.

This should get us some memory leak fixes as we've now got rid of a lot of the manual memory management that wasn't done right anyway.