### PR TITLE
Make Command Class Gobject-style Constructed

### DIFF
--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -339,7 +339,7 @@ public abstract class AppWindow : PageWindow {
         }
 
         if (desc != null) {
-            button.tooltip_text = "%s %s".printf (default_explanation, desc.get_name ());
+            button.tooltip_text = "%s %s".printf (default_explanation, desc.name);
             action.set_enabled (true);
         } else {
             button.tooltip_text = default_explanation;

--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -339,7 +339,7 @@ public abstract class AppWindow : PageWindow {
         }
 
         if (desc != null) {
-            button.tooltip_text = "%s %s".printf (default_explanation, desc.name);
+            button.tooltip_text = "%s %s".printf (default_explanation, desc.get_command_name ());
             action.set_enabled (true);
         } else {
             button.tooltip_text = default_explanation;

--- a/src/AppWindow.vala
+++ b/src/AppWindow.vala
@@ -328,18 +328,18 @@ public abstract class AppWindow : PageWindow {
     }
 
     private void on_command_manager_altered () {
-        decorate_command_manager_action (ACTION_UNDO, undo_btn, _("Undo"), get_command_manager ().get_undo_description ());
-        decorate_command_manager_action (ACTION_REDO, redo_btn, _("Redo"), get_command_manager ().get_redo_description ());
+        decorate_command_manager_action (ACTION_UNDO, undo_btn, _("Undo"), get_command_manager ().get_undo_command ());
+        decorate_command_manager_action (ACTION_REDO, redo_btn, _("Redo"), get_command_manager ().get_redo_command ());
     }
 
-    private void decorate_command_manager_action (string name, Gtk.Button button, string default_explanation, CommandDescription? desc) {
+    private void decorate_command_manager_action (string name, Gtk.Button button, string default_explanation, Command? command) {
         var action = ((SimpleAction) lookup_action (name));
         if (action == null) {
             return;
         }
 
-        if (desc != null) {
-            button.tooltip_text = "%s %s".printf (default_explanation, desc.get_command_name ());
+        if (command != null) {
+            button.tooltip_text = "%s %s".printf (default_explanation, command.name);
             action.set_enabled (true);
         } else {
             button.tooltip_text = default_explanation;

--- a/src/CommandManager.vala
+++ b/src/CommandManager.vala
@@ -16,11 +16,6 @@
 * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 * Boston, MA 02110-1301 USA
 */
-
-public interface CommandDescription : Object {
-    public abstract string get_command_name ();
-
-    public abstract string get_command_explanation ();
 }
 
 // Command's overrideable action calls are guaranteed to be called in this order:
@@ -37,7 +32,7 @@ public interface CommandDescription : Object {
 //   * redo () ...
 //
 // redo ()'s default implementation is to call execute, which in many cases is appropriate.
-public abstract class Command : Object, CommandDescription {
+public abstract class Command : Object {
     public string name { get; construct; }
     public string explanation { get; construct; }
     private weak CommandManager manager = null;
@@ -53,14 +48,6 @@ public abstract class Command : Object, CommandDescription {
 #if TRACE_DTORS
         debug ("DTOR: Command %s (%s)", name, explanation);
 #endif
-    }
-
-    public virtual string get_command_name () {
-        return name;
-    }
-
-    public virtual string get_command_explanation () {
-        return explanation;
     }
 
     public virtual void prepare () {
@@ -142,7 +129,7 @@ public class CommandManager {
         return undo_stack.size > 0;
     }
 
-    public CommandDescription? get_undo_description () {
+    public Command? get_undo_command () {
         return top (undo_stack);
     }
 
@@ -168,7 +155,7 @@ public class CommandManager {
         return redo_stack.size > 0;
     }
 
-    public CommandDescription? get_redo_description () {
+    public Command? get_redo_command () {
         return top (redo_stack);
     }
 

--- a/src/CommandManager.vala
+++ b/src/CommandManager.vala
@@ -72,14 +72,6 @@ public abstract class Command : Object, CommandDescription {
         return false;
     }
 
-    // public virtual string get_name () {
-    //     return name;
-    // }
-
-    // public virtual string get_explanation () {
-    //     return explanation;
-    // }
-
     public CommandManager? get_command_manager () {
         return manager;
     }

--- a/src/CommandManager.vala
+++ b/src/CommandManager.vala
@@ -18,9 +18,9 @@
 */
 
 public interface CommandDescription : Object {
-    public abstract string get_name ();
+    public abstract string name { get; construct; }
 
-    public abstract string get_explanation ();
+    public abstract string explanation { get; construct; }
 }
 
 // Command's overrideable action calls are guaranteed to be called in this order:
@@ -38,13 +38,15 @@ public interface CommandDescription : Object {
 //
 // redo ()'s default implementation is to call execute, which in many cases is appropriate.
 public abstract class Command : Object, CommandDescription {
-    private string name;
-    private string explanation;
+    public virtual string name { get; construct; }
+    public virtual string explanation { get; construct; }
     private weak CommandManager manager = null;
 
     protected Command (string name, string explanation) {
-        this.name = name;
-        this.explanation = explanation;
+        Object (
+            name: name,
+            explanation: explanation
+        );
     }
 
     ~Command () {
@@ -70,13 +72,13 @@ public abstract class Command : Object, CommandDescription {
         return false;
     }
 
-    public virtual string get_name () {
-        return name;
-    }
+    // public virtual string get_name () {
+    //     return name;
+    // }
 
-    public virtual string get_explanation () {
-        return explanation;
-    }
+    // public virtual string get_explanation () {
+    //     return explanation;
+    // }
 
     public CommandManager? get_command_manager () {
         return manager;

--- a/src/CommandManager.vala
+++ b/src/CommandManager.vala
@@ -18,9 +18,9 @@
 */
 
 public interface CommandDescription : Object {
-    public abstract string name { get; construct; }
+    public abstract string get_command_name ();
 
-    public abstract string explanation { get; construct; }
+    public abstract string get_command_explanation ();
 }
 
 // Command's overrideable action calls are guaranteed to be called in this order:
@@ -38,8 +38,8 @@ public interface CommandDescription : Object {
 //
 // redo ()'s default implementation is to call execute, which in many cases is appropriate.
 public abstract class Command : Object, CommandDescription {
-    public virtual string name { get; construct; }
-    public virtual string explanation { get; construct; }
+    public string name { get; construct; }
+    public string explanation { get; construct; }
     private weak CommandManager manager = null;
 
     protected Command (string name, string explanation) {
@@ -53,6 +53,14 @@ public abstract class Command : Object, CommandDescription {
 #if TRACE_DTORS
         debug ("DTOR: Command %s (%s)", name, explanation);
 #endif
+    }
+
+    public virtual string get_command_name () {
+        return name;
+    }
+
+    public virtual string get_command_explanation () {
+        return explanation;
     }
 
     public virtual void prepare () {

--- a/src/CommandManager.vala
+++ b/src/CommandManager.vala
@@ -16,7 +16,6 @@
 * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
 * Boston, MA 02110-1301 USA
 */
-}
 
 // Command's overrideable action calls are guaranteed to be called in this order:
 //

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -775,7 +775,7 @@ public abstract class CollectionPage : MediaPage {
 
         if (unenhanced_list.size == 0) {
             // Just undo if last on stack was enhance
-            EnhanceMultipleCommand cmd = get_command_manager ().get_undo_description () as EnhanceMultipleCommand;
+            EnhanceMultipleCommand cmd = get_command_manager ().get_undo_command () as EnhanceMultipleCommand;
             if (cmd != null && cmd.get_sources () == get_view ().get_selected_sources ())
                 get_command_manager ().undo ();
             else {
@@ -788,7 +788,7 @@ public abstract class CollectionPage : MediaPage {
             }
         } else {
             // Just undo if last on stack was unenhance
-            UnEnhanceMultipleCommand cmd = get_command_manager ().get_undo_description () as UnEnhanceMultipleCommand;
+            UnEnhanceMultipleCommand cmd = get_command_manager ().get_undo_command () as UnEnhanceMultipleCommand;
             if (cmd != null && cmd.get_sources () == get_view ().get_selected_sources ())
                 get_command_manager ().undo ();
             else {

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -1767,7 +1767,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
 
         if (get_photo ().is_enhanced ()) {
             // Just undo if last on stack was enhance
-            EnhanceSingleCommand cmd = get_command_manager ().get_undo_description () as EnhanceSingleCommand;
+            EnhanceSingleCommand cmd = get_command_manager ().get_undo_command () as EnhanceSingleCommand;
             if (cmd != null && cmd.source == get_photo ())
                 get_command_manager ().undo ();
             else {
@@ -1777,7 +1777,7 @@ public abstract class EditingHostPage : SinglePhotoPage {
             get_photo ().set_enhanced (false);
         } else {
             // Just undo if last on stack was unenhance
-            UnEnhanceSingleCommand cmd = get_command_manager ().get_undo_description () as UnEnhanceSingleCommand;
+            UnEnhanceSingleCommand cmd = get_command_manager ().get_undo_command () as UnEnhanceSingleCommand;
             if (cmd != null && cmd.source == get_photo ())
                 get_command_manager ().undo ();
             else {


### PR DESCRIPTION
The Command class which is the parent class of the editing tools can be converted into gobject-style construction, which will also enable editing_tools to be gobject-style constructed.