### PR TITLE
Event.vala: Fix is_in_starting_day function. Use DateTime throughout

### DIFF
--- a/src/Event.vala
+++ b/src/Event.vala
@@ -584,23 +584,22 @@ public class Event : EventSource, ContainerSource, Proxyable, Indexable {
         // media sources are stored in ViewCollection from earliest to latest
         MediaSource earliest_media = (MediaSource) ((DataView) view.get_at (0)).source;
         var earliest_tm = new DateTime.from_unix_local (earliest_media.get_exposure_time ());
+        var start_boundary_dt = new DateTime.local (
+            earliest_tm.get_year (),
+            earliest_tm.get_month (),
+            earliest_tm.get_day_of_month (),
+            EVENT_BOUNDARY_HOUR,
+            0,
+            0.0
+        );
 
-        // use earliest to generate the boundary hour for that day
-        Time start_boundary_tm = Time ();
-        start_boundary_tm.second = 0;
-        start_boundary_tm.minute = 0;
-        start_boundary_tm.hour = EVENT_BOUNDARY_HOUR;
-        start_boundary_tm.day = earliest_tm.get_day_of_month ();
-        start_boundary_tm.month = earliest_tm.get_month ();
-        start_boundary_tm.year = earliest_tm.get_year ();
-        start_boundary_tm.isdst = -1;
-
-        int64 start_boundary = start_boundary_tm.mktime ();
+        int64 start_boundary = start_boundary_dt.to_unix ();
 
         // if the earliest's exposure time was on the day but *before* the boundary hour,
         // step it back a day to the prior day's boundary
-        if (earliest_tm.get_hour () < EVENT_BOUNDARY_HOUR)
+        if (earliest_tm.get_hour () < EVENT_BOUNDARY_HOUR) {
             start_boundary -= SECONDS_PER_DAY;
+        }
 
         int64 end_boundary = (start_boundary + SECONDS_PER_DAY - 1);
 

--- a/src/VideoMetadata.vala
+++ b/src/VideoMetadata.vala
@@ -447,7 +447,7 @@ private class AVIMetadataLoader {
             return 0;
         }
 
-        Date date = Date ();
+        DateTime dt;
         uint seconds = 0;
         int year, month, day, hour, min, sec;
         char weekday[4];
@@ -464,7 +464,15 @@ private class AVIMetadataLoader {
             if (result < 5) {
                 return 0;
             }
-            date.set_dmy ((DateDay) day, (DateMonth) month, (DateYear) year);
+
+            dt = new DateTime.local (
+                year,
+                month,
+                day,
+                hour,
+                min,
+                (double)sec
+            );
             seconds = sec + min * 60 + hour * 3600;
         } else {
             // Format is: Mon Mar  3 09:44:56 2008
@@ -472,23 +480,27 @@ private class AVIMetadataLoader {
                                   out min, out sec, out year)) {
                 return 0; // Error
             }
-            date.set_dmy ((DateDay) day, month_from_string ((string) monthstr), (DateYear) year);
+
+            dt = new DateTime.local (
+                year,
+                month_from_string ((string) monthstr),
+                day,
+                hour,
+                min,
+                (double)sec
+            );
             seconds = sec + min * 60 + hour * 3600;
         }
 
-        Time time = Time ();
-        date.to_time (out time);
-
         // watch for overflow (happens on quasi-bogus dates, like Year 200)
-        int64 tm = time.mktime ();
+        int64 tm = dt.to_unix ();
         int64 result = tm + seconds;
         if (result < tm) {
             debug ("Overflow for timestamp in video file %s", file.get_path ());
-
             return 0;
         }
 
-        return result;
+        return tm;
     }
 
     private DateMonth month_from_string (string s) {


### PR DESCRIPTION
Fixes #628 

Fixes regression caused by incomplete conversion to DateTime from Time () in commit addac7152d803acc12231293200be64adfa8d1b8

Unfortunately any photos imported with the faulty version will have to be reimported or manually grouped into a single event for the day on which they were taken.

Another place was also found where Time () should have been replaced with DateTime () so that is also fixed.