### PR TITLE
Plugins: Fix deprecations

### DIFF
--- a/plugins/pantheon-photos-publishing-extras/RESTSupport.vala
+++ b/plugins/pantheon-photos-publishing-extras/RESTSupport.vala
@@ -439,7 +439,7 @@ public class UploadTransaction : Transaction {
 
         int payload_part_num = message_parts.get_length ();
 
-        Soup.Buffer bindable_data = new Soup.Buffer (Soup.MemoryUse.COPY, payload.data[0:payload_length]);
+        Soup.Buffer bindable_data = new Soup.Buffer.take (payload.data[0:payload_length]);
         message_parts.append_form_file ("", publishable.get_serialized_file ().get_path (), mime_type,
         bindable_data);
 
@@ -754,7 +754,6 @@ public abstract class GooglePublisher : Object, Spit.Publishing.Publisher {
             webview_frame.expand = true;
 
             webview = new WebKit.WebView ();
-            webview.get_settings ().enable_plugins = false;
             webview.load_changed.connect ((load_event) => {
                 if (load_event == WebKit.LoadEvent.STARTED) {
                     on_load_started ();

--- a/plugins/pantheon-photos-publishing-extras/YandexPublishing.vala
+++ b/plugins/pantheon-photos-publishing-extras/YandexPublishing.vala
@@ -133,8 +133,6 @@ internal class WebAuthPane : Spit.Publishing.DialogPane, GLib.Object {
         webview_frame.expand = true;
 
         webview = new WebKit.WebView ();
-        webview.get_settings ().enable_plugins = false;
-
         webview.load_changed.connect ((load_event) => {
             if (load_event == WebKit.LoadEvent.STARTED) {
                 on_load_started ();
@@ -321,7 +319,7 @@ private class UploadTransaction: Transaction {
 
         int image_part_num = message_parts.get_length ();
 
-        Soup.Buffer bindable_data = new Soup.Buffer (Soup.MemoryUse.COPY, photo_data.data[0:data_length]);
+        Soup.Buffer bindable_data = new Soup.Buffer.take (photo_data.data[0:data_length]);
         message_parts.append_form_file ("", photo.get_serialized_file ().get_path (), "image/jpeg", bindable_data);
 
         unowned Soup.MessageHeaders image_part_header;

--- a/plugins/pantheon-photos-publishing/FacebookPublishing.vala
+++ b/plugins/pantheon-photos-publishing/FacebookPublishing.vala
@@ -835,8 +835,6 @@ internal class WebAuthenticationPane : Spit.Publishing.DialogPane, Object {
         webview_frame.expand = true;
 
         webview = new WebKit.WebView ();
-        webview.get_settings ().enable_plugins = false;
-
         webview.load_changed.connect ((load_event) => {
             if (load_event == WebKit.LoadEvent.STARTED) {
                 on_load_started ();
@@ -1393,7 +1391,7 @@ internal class GraphSession {
             unowned uint8[] payload = (uint8[]) mapped_file.get_contents ();
             payload.length = (int) mapped_file.get_length ();
 
-            Soup.Buffer image_data = new Soup.Buffer (Soup.MemoryUse.TEMPORARY, payload);
+            Soup.Buffer image_data = new Soup.Buffer.take (payload);
 
             Soup.Multipart mp_envelope = new Soup.Multipart ("multipart/form-data");
 

--- a/plugins/pantheon-photos-publishing/PicasaPublishing.vala
+++ b/plugins/pantheon-photos-publishing/PicasaPublishing.vala
@@ -336,7 +336,7 @@ internal class UploadTransaction :
         string metadata = METADATA_TEMPLATE.printf (Publishing.RESTSupport.decimal_entity_encode (
                               publishable.get_param_string (Spit.Publishing.Publishable.PARAM_STRING_BASENAME)),
                           summary, keywords_string);
-        Soup.Buffer metadata_buffer = new Soup.Buffer (Soup.MemoryUse.COPY, metadata.data);
+        Soup.Buffer metadata_buffer = new Soup.Buffer.take (metadata.data);
         message_parts.append_form_file ("", "", "application/atom+xml", metadata_buffer);
 
         // attempt to map the binary image data from disk into memory
@@ -355,7 +355,7 @@ internal class UploadTransaction :
         // bind the binary image data read from disk into a Soup.Buffer object so that we
         // can attach it to the multipart request, then actaully append the buffer
         // to the multipart request. Then, set the MIME type for this part.
-        Soup.Buffer bindable_data = new Soup.Buffer (Soup.MemoryUse.TEMPORARY, photo_data);
+        Soup.Buffer bindable_data = new Soup.Buffer.take (photo_data);
 
         message_parts.append_form_file ("", publishable.get_serialized_file ().get_path (), mime_type,
         bindable_data);

--- a/plugins/pantheon-photos-publishing/RESTSupport.vala
+++ b/plugins/pantheon-photos-publishing/RESTSupport.vala
@@ -439,7 +439,7 @@ public class UploadTransaction : Transaction {
 
         int payload_part_num = message_parts.get_length ();
 
-        Soup.Buffer bindable_data = new Soup.Buffer (Soup.MemoryUse.COPY, payload.data[0:payload_length]);
+        Soup.Buffer bindable_data = new Soup.Buffer.take (payload.data[0:payload_length]);
         message_parts.append_form_file ("", publishable.get_serialized_file ().get_path (), mime_type,
         bindable_data);
 
@@ -754,7 +754,6 @@ public abstract class GooglePublisher : Object, Spit.Publishing.Publisher {
             webview_frame.expand = true;
 
             webview = new WebKit.WebView ();
-            webview.get_settings ().enable_plugins = false;
             webview.load_changed.connect ((load_event) => {
                 if (load_event == WebKit.LoadEvent.STARTED) {
                     on_load_started ();

--- a/plugins/pantheon-photos-publishing/YouTubePublishing.vala
+++ b/plugins/pantheon-photos-publishing/YouTubePublishing.vala
@@ -573,7 +573,7 @@ internal class UploadTransaction : Publishing.RESTSupport.GooglePublisher.Authen
 
         string metadata = METADATA_TEMPLATE.printf (Publishing.RESTSupport.decimal_entity_encode (title),
         private_video, unlisted_video);
-        Soup.Buffer metadata_buffer = new Soup.Buffer (Soup.MemoryUse.COPY, metadata.data);
+        Soup.Buffer metadata_buffer = new Soup.Buffer.take (metadata.data);
         message_parts.append_form_file ("", "", "application/atom+xml", metadata_buffer);
 
         // attempt to read the binary video data from disk
@@ -593,8 +593,7 @@ internal class UploadTransaction : Publishing.RESTSupport.GooglePublisher.Authen
         // bind the binary video data read from disk into a Soup.Buffer object so that we
         // can attach it to the multipart request, then actaully append the buffer
         // to the multipart request. Then, set the MIME type for this part.
-        Soup.Buffer bindable_data = new Soup.Buffer (Soup.MemoryUse.COPY,
-        video_data.data[0:data_length]);
+        Soup.Buffer bindable_data = new Soup.Buffer.take (video_data.data[0:data_length]);
 
         message_parts.append_form_file ("", publishable.get_serialized_file ().get_path (),
         "video/mpeg", bindable_data);


### PR DESCRIPTION
According to [this](https://github.com/WebKit/WebKit/blob/a8cdd64386ba4ac30479fdc25f5a9a2acc930813/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp#L1896) we can remove the deprecated `WebKit.settings.enable_plugins` instead of replacing it with another code
