### PR TITLE
Fix invalid cast  from Video to Photo

### DIFF
--- a/src/Commands.vala
+++ b/src/Commands.vala
@@ -1199,7 +1199,11 @@ public class SetRawDeveloperCommand : MultipleDataSourceCommand {
         last_transformation_map = new Gee.HashMap<Photo, PhotoTransformationState> ();
 
         foreach (DataView view in iter) {
-            Photo? photo = view.source as Photo;
+            Photo? photo = null;
+            if (view.source is Photo) {
+                photo = view.source as Photo;
+            }
+
             if (is_raw_photo (photo)) {
                 last_developer_map[photo] = photo.get_raw_developer ();
                 last_transformation_map[photo] = photo.save_transformation_state ();
@@ -1216,7 +1220,11 @@ public class SetRawDeveloperCommand : MultipleDataSourceCommand {
     }
 
     public override void execute_on_source (DataSource source) {
-        Photo? photo = source as Photo;
+        Photo? photo = null;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (is_raw_photo (photo)) {
             if (new_developer == RawDeveloper.CAMERA && !photo.is_raw_developer_available (RawDeveloper.CAMERA))
                 photo.set_raw_developer (RawDeveloper.EMBEDDED);
@@ -1226,7 +1234,11 @@ public class SetRawDeveloperCommand : MultipleDataSourceCommand {
     }
 
     public override void undo_on_source (DataSource source) {
-        Photo? photo = source as Photo;
+        Photo? photo = null;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (is_raw_photo (photo)) {
             photo.set_raw_developer (last_developer_map[photo]);
             photo.load_transformation_state (last_transformation_map[photo]);

--- a/src/MediaViewTracker.vala
+++ b/src/MediaViewTracker.vala
@@ -41,7 +41,11 @@ public class MediaAccumulator : Object, Core.TrackerAccumulator {
 
         total++;
 
-        Photo? photo = source as Photo;
+        Photo? photo = null;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (photo != null) {
             if (photo.get_master_file_format () == PhotoFileFormat.RAW) {
                 raw++;

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -2214,7 +2214,11 @@ public abstract class Photo : PhotoSource, Dateable {
 
     public override bool equals (DataSource? source) {
         // Primary key is where the rubber hits the road
-        Photo? photo = source as Photo;
+        Photo? photo = null;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (photo != null) {
             PhotoID photo_id = get_photo_id ();
             PhotoID other_photo_id = photo.get_photo_id ();

--- a/src/ThumbnailCache.vala
+++ b/src/ThumbnailCache.vala
@@ -413,8 +413,13 @@ public class ThumbnailCache : Object {
         } catch (Error err) {
             if (err is FileError) {
                 try {
-                    Photo photo = source as Photo;
-                    Video video = source as Video;
+                    Photo? photo = null;
+                    Video? video = null;
+                    if (source is Photo) {
+                        photo = source as Photo;
+                    } else if (source is Video) {
+                        video = source as Video;
+                    }
 
                     if (photo != null) {
                         pixbuf = photo.get_pixbuf (Scaling.for_best_fit (size.get_scale () * scale_factor, true));

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -233,7 +233,12 @@ public abstract class CollectionPage : MediaPage {
             item_context_menu.show_all ();
         }
 
-        Photo? photo = (get_view ().get_selected_at (0).source as Photo);
+        Photo? photo = null;
+        DataSource? source = get_view ().get_selected_at (0).source;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (photo != null) {
             unowned PhotoFileFormat photo_file_format = photo.get_master_file_format ();
             populate_external_app_menu (open_menu, photo_file_format, false);
@@ -360,7 +365,12 @@ public abstract class CollectionPage : MediaPage {
         if (get_view ().get_selected_count () != 1)
             return;
 
-        Photo? photo = get_view ().get_selected_at (0).source as Photo;
+        Photo? photo = null;
+        DataSource? source = get_view ().get_selected_at (0).source;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         try {
             AppWindow.get_instance ().set_busy_cursor ();
             photo.open_with_external_editor (app);
@@ -375,8 +385,13 @@ public abstract class CollectionPage : MediaPage {
         if (get_view ().get_selected_count () != 1)
             return;
 
-        Photo photo = (Photo) get_view ().get_selected_at (0).source;
-        if (photo.get_master_file_format () != PhotoFileFormat.RAW)
+        Photo? photo = null;
+        DataSource? source = get_view ().get_selected_at (0).source;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+        // Photo photo = (Photo) get_view ().get_selected_at (0).source;
+        if (photo == null || photo.get_master_file_format () != PhotoFileFormat.RAW)
             return;
 
         try {
@@ -478,7 +493,11 @@ public abstract class CollectionPage : MediaPage {
     private void update_enhance_toggled () {
         bool toggled = false;
         foreach (DataView view in get_view ().get_selected ()) {
-            Photo photo = view.source as Photo;
+            Photo? photo = null;
+            if (view.source is Photo) {
+                photo = view.source as Photo;
+            }
+
             if (photo != null && !photo.is_enhanced ()) {
                 toggled = false;
                 break;
@@ -735,8 +754,10 @@ public abstract class CollectionPage : MediaPage {
     }
 
     public void on_copy_adjustments () {
-        if (get_view ().get_selected_count () != 1)
+        if (get_view ().get_selected_count () != 1 || !(get_view ().get_selected_at (0).source is Photo)) {
             return;
+        }
+
         Photo photo = (Photo) get_view ().get_selected_at (0).source;
         PixelTransformationBundle.set_copied_color_adjustments (photo.get_color_adjustments ());
         set_action_sensitive ("PasteColorAdjustments", true);
@@ -763,7 +784,11 @@ public abstract class CollectionPage : MediaPage {
         Gee.ArrayList<DataView> unenhanced_list = new Gee.ArrayList<DataView> ();
         Gee.ArrayList<DataView> enhanced_list = new Gee.ArrayList<DataView> ();
         foreach (DataView view in get_view ().get_selected ()) {
-            Photo photo = view.source as Photo;
+            Photo? photo = null;
+            if (view.source is Photo) {
+                photo = view.source as Photo;
+            }
+
             if (photo != null && !photo.is_enhanced ())
                 unenhanced_list.add (view);
             else if (photo != null)
@@ -783,7 +808,11 @@ public abstract class CollectionPage : MediaPage {
                 get_command_manager ().execute (command);
             }
             foreach (DataView view in enhanced_list) {
-                Photo photo = view.source as Photo;
+                Photo? photo = null;
+                if (view.source is Photo) {
+                    photo = view.source as Photo;
+                }
+
                 photo.set_enhanced (false);
             }
         } else {
@@ -796,7 +825,11 @@ public abstract class CollectionPage : MediaPage {
                 get_command_manager ().execute (command);
             }
             foreach (DataView view in enhanced_list) {
-                Photo photo = view.source as Photo;
+                Photo? photo = null;
+                if (view.source is Photo) {
+                    photo = view.source as Photo;
+                }
+
                 photo.set_enhanced (true);
             }
         }

--- a/src/Views/LibraryPhotoPage.vala
+++ b/src/Views/LibraryPhotoPage.vala
@@ -250,7 +250,12 @@ public class LibraryPhotoPage : EditingHostPage {
         if (get_view ().get_selected_count () != 1)
             return;
 
-        Photo? photo = get_view ().get_selected ().get (0).source as Photo;
+        Photo? photo = null;
+        DataSource? source = get_view ().get_selected ().get (0).source;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (photo == null || rd.is_equivalent (photo.get_raw_developer ()))
             return;
 
@@ -588,7 +593,12 @@ public class LibraryPhotoPage : EditingHostPage {
             item_context_menu.show_all ();
         }
 
-        Photo? photo = (get_view ().get_selected_at (0).source as Photo);
+        Photo? photo = null;
+        DataSource? source = get_view ().get_selected_at (0).source;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (photo != null) {
             unowned PhotoFileFormat photo_file_format = photo.get_master_file_format ();
             populate_external_app_menu (open_menu, photo_file_format, false);

--- a/src/Views/MediaPage.vala
+++ b/src/Views/MediaPage.vala
@@ -417,6 +417,24 @@ public abstract class MediaPage : CheckerboardPage {
         }
     }
 
+    public void open_video_with (AppInfo app) {
+        if (get_view ().get_selected_count () != 1 || !(get_view ().get_selected_at (0).source is Video))
+            return;
+
+        Video? video = get_view ().get_selected_at (0).source as Video;
+        if (video == null)
+            return;
+
+        try {
+            List<string> videos = null;
+            videos.append (video.get_file ().get_uri ());
+            app.launch_uris (videos, null);
+        } catch (Error e) {
+            AppWindow.error_message (_ ("Photos was unable to play the selected video:\n%s").printf (
+                                         e.message));
+        }
+    }
+
     protected override bool on_app_key_pressed (Gdk.EventKey event) {
         bool handled = true;
         switch (Gdk.keyval_name (event.keyval)) {

--- a/src/Views/MediaPage.vala
+++ b/src/Views/MediaPage.vala
@@ -402,7 +402,7 @@ public abstract class MediaPage : CheckerboardPage {
     }
 
     protected void on_play_video () {
-        if (get_view ().get_selected_count () != 1)
+        if (get_view ().get_selected_count () != 1 || !(get_view ().get_selected_at (0).source is Video))
             return;
 
         Video? video = get_view ().get_selected_at (0).source as Video;
@@ -630,7 +630,10 @@ public abstract class MediaPage : CheckerboardPage {
         // Make a list of all photos that need their developer changed.
         Gee.ArrayList<DataView> to_set = new Gee.ArrayList<DataView> ();
         foreach (DataView view in get_view ().get_selected ()) {
-            Photo? p = view.source as Photo;
+            Photo? p = null;
+            if (view.source is Photo) {
+                p = view.source as Photo;
+            }
             if (p != null && (!rd.is_equivalent (p.get_raw_developer ()))) {
                 to_set.add (view);
 

--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -104,9 +104,15 @@ public abstract class Page : Gtk.ScrolledWindow {
         Gee.List<Granite.Services.Contract> contracts = null;
         try {
             var selected = get_view ().get_selected_sources ();
-            foreach (var item in selected)
-                files += (((Photo)item).get_file ());
-            contracts = Granite.Services.ContractorProxy.get_contracts_for_files (files);
+            foreach (var item in selected) {
+                if (item is Photo) {
+                    files += (((Photo)item).get_file ());
+                }
+            }
+
+            if (files.length > 0) {
+                contracts = Granite.Services.ContractorProxy.get_contracts_for_files (files);
+            }
         } catch (Error e) {
             warning (e.message);
         }
@@ -116,14 +122,17 @@ public abstract class Page : Gtk.ScrolledWindow {
         });
 
         //and replace it with menu_item from contractor
-        for (int i = 0; i < contracts.size; i++) {
-            var contract = contracts.get (i);
-            Gtk.MenuItem menu_item;
+        if (contracts != null) {
+            for (int i = 0; i < contracts.size; i++) {
+                var contract = contracts.get (i);
+                Gtk.MenuItem menu_item;
 
-            menu_item = new ContractMenuItem (contract, get_view ().get_selected_sources ());
-            menu.append (menu_item);
-            contractor_menu_items.append (menu_item);
+                menu_item = new ContractMenuItem (contract, get_view ().get_selected_sources ());
+                menu.append (menu_item);
+                contractor_menu_items.append (menu_item);
+            }
         }
+
         menu.show_all ();
     }
 

--- a/src/Views/PhotosPage.vala
+++ b/src/Views/PhotosPage.vala
@@ -42,8 +42,12 @@ public class Library.PhotosPage : CollectionPage {
         }
 
         public override bool include_in_view (DataSource source) {
+            if (!(source is Photo)) {
+                return false;
+            }
+
             Photo photo = (Photo) source;
-            return source is Photo && photo != null && photo.get_master_file_format () != PhotoFileFormat.RAW;
+            return photo != null && photo.get_master_file_format () != PhotoFileFormat.RAW;
         }
     }
 

--- a/src/Views/RawsPage.vala
+++ b/src/Views/RawsPage.vala
@@ -42,7 +42,10 @@ public class Library.RawsPage : CollectionPage {
         }
 
         public override bool include_in_view (DataSource source) {
-            unowned Photo? photo = source as Photo;
+            Photo? photo = null;
+            if (source is Photo) {
+                photo = source as Photo;
+            }
             return photo != null && photo.get_master_file_format () == PhotoFileFormat.RAW;
         }
     }

--- a/src/searches/SearchBoolean.vala
+++ b/src/searches/SearchBoolean.vala
@@ -612,7 +612,11 @@ public class SearchConditionModified : SearchCondition {
     // Determines whether the source is included.
     public override bool predicate (MediaSource source) {
         // check against state and the given search context.
-        Photo? photo = source as Photo;
+        Photo? photo = null;
+        if (source is Photo) {
+            photo = source as Photo;
+        }
+
         if (photo == null)
             return false;
 


### PR DESCRIPTION
This fixes a terminal warning about casting a Video to a Photo when Photos is opened and there are Videos in the library.

Most of the checks before casting are probably not actually necessary but were fixed anyway.

Also the second commit fixes a problem where the context menu on Videos had a "Open in" option but the submenu was empty.

 Video handling in Photos (e.g. thumbnailing) is not very good.  It needs to be decided whether it is worth continuing video support before spending the time to improve it.