### PR TITLE
Make CropTools Gobject-style constructed

### DIFF
--- a/src/editing_tools/AdjustTool.vala
+++ b/src/editing_tools/AdjustTool.vala
@@ -376,7 +376,9 @@ public class EditingTools.AdjustTool : EditingTool {
     private OneShotScheduler? highlights_scheduler = null;
 
     private AdjustTool () {
-        base ("AdjustTool");
+        Object (
+            name: "AdjustTool"
+        );
     }
 
     public static AdjustTool factory () {

--- a/src/editing_tools/AdjustTool.vala
+++ b/src/editing_tools/AdjustTool.vala
@@ -376,9 +376,7 @@ public class EditingTools.AdjustTool : EditingTool {
     private OneShotScheduler? highlights_scheduler = null;
 
     private AdjustTool () {
-        Object (
-            name: "AdjustTool"
-        );
+        Object (name: "AdjustTool");
     }
 
     public static AdjustTool factory () {

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -208,9 +208,7 @@ public class EditingTools.CropTool : EditingTool {
     private GLib.Settings crop_settings;
 
     private CropTool () {
-        Object (
-            name: "CropTool"
-        );
+        Object (name: "CropTool");
 
     }
 

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -918,7 +918,7 @@ public class EditingTools.CropTool : EditingTool {
             case BoxLocation.LEFT_SIDE:
                 left = x;
                 if (get_constraint_aspect_ratio () != ANY_ASPECT_RATIO) {
-                    float new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
+                    var new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
                     bottom = top + ((int) new_height);
                 }
                 break;

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -992,7 +992,7 @@ public class EditingTools.CropTool : EditingTool {
                         right = left + ((int) new_width);
                     } else {
                         right = x;
-                        float new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
+                        var new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
                         top = bottom - ((int) new_height);
                     }
                 }

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -1009,7 +1009,7 @@ public class EditingTools.CropTool : EditingTool {
                         bottom = top + ((int) new_height);
                     } else {
                         bottom = y;
-                        float new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
+                        var new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
                         right = left + ((int) new_width);
                     }
                 }

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -942,7 +942,7 @@ public class EditingTools.CropTool : EditingTool {
             case BoxLocation.BOTTOM_SIDE:
                 bottom = y;
                 if (get_constraint_aspect_ratio () != ANY_ASPECT_RATIO) {
-                    float new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
+                    var new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
                     right = left + ((int) new_width);
                 }
                 break;

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -971,7 +971,7 @@ public class EditingTools.CropTool : EditingTool {
                 } else {
                     if (y < eval_radial_line (center_x, center_y, left, bottom, x)) {
                         left = x;
-                        float new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
+                        var new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
                         bottom = top + ((int) new_height);
                     } else {
                         bottom = y;

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -975,7 +975,7 @@ public class EditingTools.CropTool : EditingTool {
                         bottom = top + ((int) new_height);
                     } else {
                         bottom = y;
-                        float new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
+                        var new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
                         left = right - ((int) new_width);
                     }
                 }

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -1005,7 +1005,7 @@ public class EditingTools.CropTool : EditingTool {
                 } else {
                     if (y < eval_radial_line (center_x, center_y, right, bottom, x)) {
                         right = x;
-                        float new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
+                        var new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
                         bottom = top + ((int) new_height);
                     } else {
                         bottom = y;

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -1110,8 +1110,8 @@ public class EditingTools.CropTool : EditingTool {
                     if (width < CROP_MIN_SIZE) {
                         right = left + CROP_MIN_SIZE;
                     }
-                    break;
 
+                    break;
                 default:
                     break;
             }

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -958,7 +958,7 @@ public class EditingTools.CropTool : EditingTool {
                         left = right - ((int) new_width);
                     } else {
                         left = x;
-                        float new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
+                        var new_height = ((float) (right - left)) / get_constraint_aspect_ratio ();
                         top = bottom - ((int) new_height);
                     }
                 }

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -954,7 +954,7 @@ public class EditingTools.CropTool : EditingTool {
                 } else {
                     if (y < eval_radial_line (center_x, center_y, left, top, x)) {
                         top = y;
-                        float new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
+                        var new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
                         left = right - ((int) new_width);
                     } else {
                         left = x;

--- a/src/editing_tools/CropTool.vala
+++ b/src/editing_tools/CropTool.vala
@@ -988,7 +988,7 @@ public class EditingTools.CropTool : EditingTool {
                 } else {
                     if (y < eval_radial_line (center_x, center_y, right, top, x)) {
                         top = y;
-                        float new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
+                        var new_width = ((float) (bottom - top)) * get_constraint_aspect_ratio ();
                         right = left + ((int) new_width);
                     } else {
                         right = x;


### PR DESCRIPTION
Next to EditingTools, make children classes gobject style constructed. Starting with CropTools. Also fixed a simple block in AdjustTools.