### PR TITLE
Lose unnecessary private copies of ui_settings

### DIFF
--- a/src/Views/EventsDirectoryPage.vala
+++ b/src/Views/EventsDirectoryPage.vala
@@ -56,11 +56,8 @@ public abstract class EventsDirectoryPage : CheckerboardPage {
     private EventsDirectorySearchViewFilter search_filter = new EventsDirectorySearchViewFilter ();
     private Gtk.Menu page_context_menu;
     private Gtk.Menu item_context_menu;
-    private GLib.Settings ui_settings;
 
     construct {
-        ui_settings = new GLib.Settings (GSettingsConfigurationEngine.UI_PREFS_SCHEMA_NAME);
-
         var merge_button = new Gtk.Button.from_icon_name (Resources.MERGE, Gtk.IconSize.LARGE_TOOLBAR);
         merge_button.related_action = get_action ("Merge");
         merge_button.tooltip_text = _("Merge events");

--- a/src/Views/ImportPage.vala
+++ b/src/Views/ImportPage.vala
@@ -722,17 +722,12 @@ public class ImportPage : CheckerboardPage {
 
     private Gtk.Menu page_context_menu;
     private Gtk.Menu import_context_menu;
-    private GLib.Settings ui_settings;
 
     public enum RefreshResult {
         OK,
         BUSY,
         LOCKED,
         LIBRARY_ERROR
-    }
-
-    construct {
-        ui_settings = new GLib.Settings (GSettingsConfigurationEngine.UI_PREFS_SCHEMA_NAME);
     }
 
     public ImportPage (GPhoto.Camera camera, string uri, string? display_name = null, GLib.Icon? icon = null) {


### PR DESCRIPTION
* Stop critical terminal warning showing certain views