### PR TITLE
Resources: use fd.o icon name for calendar

### DIFF
--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -65,9 +65,9 @@ public const string ICON_SELECTION_ADD = "selection-add";
 public const string ICON_SELECTION_REMOVE = "selection-remove";
 
 public const string ICON_CAMERAS = "camera-photo";
-public const string ICON_EVENTS = "office-calendar";
-public const string ICON_ONE_EVENT = "office-calendar";
-public const string ICON_NO_EVENT = "office-calendar";
+public const string ICON_EVENTS = "x-office-calendar";
+public const string ICON_ONE_EVENT = "x-office-calendar";
+public const string ICON_NO_EVENT = "x-office-calendar";
 public const string ICON_ONE_TAG = "folder-tag";
 public const string ICON_TAGS = "folder-tag";
 public const string ICON_FOLDER_CLOSED = "folder";


### PR DESCRIPTION
The icon name `office-calendar` doesn't exist in fd.o, but `x-office-calendar` does https://specifications.freedesktop.org/icon-naming-spec/latest/ar01s04.html