### PR TITLE
Fix translation charset

### DIFF
--- a/po/extra/zh_HK.po
+++ b/po/extra/zh_HK.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: none\n"
 "Language: zh_HK\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=BIG5-HKSCS\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/io.elementary.photos-viewer.desktop.in.in:3


### PR DESCRIPTION
Right now we are not able to build Photos on Fedora 37:

https://github.com/meisenzahl/distro-agnostic/actions/runs/3987907130/jobs/6838343834#step:5:16634

This small change fixes this:

https://github.com/meisenzahl/distro-agnostic/actions/runs/3988175247/jobs/6838977411#step:5:18232

@ryonakano do you have any concerns changing the charset?