### PR TITLE
docs: Declare libhandy-1 dependency

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -21,6 +21,7 @@ basic_command = [
     '--pkg', 'json-glib-1.0',
     '--pkg', 'libexif',
     '--pkg', 'libgphoto2',
+    '--pkg', 'libhandy-1',
     '--pkg', 'libraw',
     '--pkg', 'libwebp',
     '--pkg', 'libxml-2.0',


### PR DESCRIPTION
Motivated by https://github.com/elementary/mail/pull/917, I tried to build the docs here and found it fails as well :thinking: 

```
EditingToolWindow.vala:21.56-21.58: error: The symbol `Hdy' could not be found
AppWindow.vala:39.15-39.17: error: The symbol `Hdy' could not be found
PageWindow.vala:28.36-28.38: error: The symbol `Hdy' could not be found
```
