### PR TITLE
Fix viewer not being exported in Flatpak

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -15,12 +15,12 @@ foreach i : icon_sizes
     install_data(
         join_paths('icons', i + '-viewer.svg'),
         install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps'),
-        rename: meson.project_name() + '-viewer.svg'
+        rename: meson.project_name() + '.viewer.svg'
     )
     install_data(
         join_paths('icons', i + '-viewer.svg'),
         install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps'),
-        rename: meson.project_name() + '-viewer.svg'
+        rename: meson.project_name() + '.viewer.svg'
     )
 endforeach
 
@@ -34,14 +34,14 @@ config_data.set('EXEC_NAME', meson.project_name())
 
 # Set the executable name and translate the desktop files
 viewer_desktop_in_file = configure_file(
-    input: meson.project_name() + '-viewer.desktop.in.in',
+    input: 'viewer.desktop.in.in',
     output: '@BASENAME@',
     configuration: config_data
 )
 
 viewer_desktop_file = i18n.merge_file(
     input: viewer_desktop_in_file,
-    output: meson.project_name() + '-viewer.desktop',
+    output: meson.project_name() + '.viewer.desktop',
     po_dir: join_paths(meson.source_root (), 'po', 'extra'),
     type: 'desktop',
     install_dir: join_paths(get_option('datadir'), 'applications'),

--- a/data/viewer.desktop.in.in
+++ b/data/viewer.desktop.in.in
@@ -2,7 +2,7 @@
 Name=Photo Viewer
 GenericName=Photo Viewer
 Exec=@EXEC_NAME@ %U
-Icon=io.elementary.photos-viewer
+Icon=io.elementary.photos.viewer
 Terminal=false
 NoDisplay=true
 Type=Application

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,3 +1,3 @@
-data/io.elementary.photos-viewer.desktop.in.in
+data/viewer.desktop.in.in
 data/io.elementary.photos.desktop.in.in
 data/photos.metainfo.xml.in


### PR DESCRIPTION
Desktops have to be prefixed with the app ID to be exported under flatpak, so we use a `.` not a `-` for the viewer desktop file