### PR TITLE
gschema: Remove alias to sharing

### DIFF
--- a/data/io.elementary.photos.gschema.xml
+++ b/data/io.elementary.photos.gschema.xml
@@ -2,7 +2,6 @@
 
 <schema id="io.elementary.photos" path="/io/elementary/photos/">
     <child name="preferences" schema="io.elementary.photos.preferences" />
-    <child name="sharing" schema="io.elementary.photos.sharing" />
     <child name="video" schema="io.elementary.photos.video" />
     <child name="printing" schema="io.elementary.photos.printing" />
     <child name="plugins" schema="io.elementary.photos.plugins" />


### PR DESCRIPTION
Followup #761

This fixes the warning when compiling schemas:

```
user@VirtualBox-17958d80:~/work/switchboard-plug-locale$ LANG=C sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
Warning: undefined reference to <schema id='io.elementary.photos.sharing'/>
user@VirtualBox-17958d80:~/work/switchboard-plug-locale$ 
```