### PR TITLE
AppDirs: Fix loading plugins

### DIFF
--- a/src/AppDirs.vala
+++ b/src/AppDirs.vala
@@ -238,7 +238,7 @@ class AppDirs {
     public static File get_lib_dir () {
         File? install_dir = get_install_dir ();
 
-        return (install_dir != null) ? install_dir.get_child (Resources.LIB).get_child (PROJECT_NAME)
+        return (install_dir != null) ? File.new_for_path (Resources.LIB).get_child (PROJECT_NAME)
                : get_exec_dir ();
     }
 


### PR DESCRIPTION
`Resources.LIB` already has the `/usr` (or `/app` if Flatpak) prefix in meson.build so the previous code tries to search for `/usr/usr/lib/x86_64-linux-gnu` or `/app/app/lib` and causes the critical messages displayed on the terminal when launching and plugins not shown in the preferences dialog.

### Before

```
user@VirtualBox-17958d80:~/work/photos$ LANG=C io.elementary.photos 
** Message: 01:20:46.822: main.vala:347: Photos Photo Manager 8.0.0

(io.elementary.photos:67956): GLib-GIO-CRITICAL **: 01:20:46.835: g_file_get_child: assertion '!g_path_is_absolute (name)' failed

(io.elementary.photos:67956): GLib-GIO-CRITICAL **: 01:20:46.835: g_file_get_child: assertion 'G_IS_FILE (file)' failed

(io.elementary.photos:67956): GLib-GIO-CRITICAL **: 01:20:46.835: g_file_get_child: assertion 'G_IS_FILE (file)' failed

** (io.elementary.photos:67956): CRITICAL **: 01:20:46.836: plugins_search_for_plugins: assertion 'dir != NULL' failed
** Message: 01:20:46.836: main.vala:57: Verifying database ?
** Message: 01:20:46.841: VideoSupport.vala:403: interpreter state cookie not found; assuming all video thumbnails are out of date

(io.elementary.photos:67956): GLib-GObject-CRITICAL **: 01:20:46.884: value "-1" of type 'gint' is invalid or out of range for property 'position' of type 'gint'
```

![Screenshot from 2024-06-30 10-29-04](https://github.com/elementary/photos/assets/26003928/42b2f5e5-338f-4f52-8f46-89cc72b24e1e)

### After

```
user@VirtualBox-17958d80:~/work/photos$ LANG=C io.elementary.photos 
** Message: 01:21:07.239: main.vala:347: Photos Photo Manager 8.0.0
** Message: 01:21:07.254: main.vala:57: Verifying database ?
** Message: 01:21:07.260: VideoSupport.vala:403: interpreter state cookie not found; assuming all video thumbnails are out of date

(io.elementary.photos:68045): GLib-GObject-CRITICAL **: 01:21:07.289: value "-1" of type 'gint' is invalid or out of range for property 'position' of type 'gint'
```

![Screenshot from 2024-06-30 10-27-49](https://github.com/elementary/photos/assets/26003928/e9065a30-a329-40a0-aff4-e66157e3283b)
