### PR TITLE
Flatpak: add sandbox hole for home

### DIFF
--- a/io.elementary.photos.json
+++ b/io.elementary.photos.json
@@ -5,7 +5,7 @@
     "sdk": "io.elementary.Sdk",
     "command": "io.elementary.photos",
     "finish-args": [
-        "--filesystem=xdg-pictures",
+        "--filesystem=home",
         "--filesystem=/media",
         "--filesystem=/run/media",
         "--filesystem=/mnt",


### PR DESCRIPTION
It turns out we need a sandbox hole for home because the photos viewer can't open files outside the sandbox