### PR TITLE
Modernize desktop files, simplify build

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -29,37 +29,21 @@ install_data(
     install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'glib-2.0', 'schemas')
 )
 
-config_data = configuration_data()
-config_data.set('EXEC_NAME', meson.project_name())
-
-# Set the executable name and translate the desktop files
-viewer_desktop_in_file = configure_file(
-    input: 'viewer.desktop.in.in',
-    output: '@BASENAME@',
-    configuration: config_data
-)
-
-viewer_desktop_file = i18n.merge_file(
-    input: viewer_desktop_in_file,
+i18n.merge_file(
+    input: 'viewer.desktop.in',
     output: meson.project_name() + '.viewer.desktop',
-    po_dir: join_paths(meson.source_root (), 'po', 'extra'),
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'desktop',
-    install_dir: join_paths(get_option('datadir'), 'applications'),
+    install_dir: get_option('datadir') / 'applications',
     install: true
 )
 
-app_desktop_in_file = configure_file(
-    input: meson.project_name() + '.desktop.in.in',
-    output: '@BASENAME@',
-    configuration: config_data
-)
-
-app_desktop_file = i18n.merge_file(
-    input: app_desktop_in_file,
+i18n.merge_file(
+    input: 'photos.desktop.in',
     output: meson.project_name() + '.desktop',
-    po_dir: join_paths(meson.source_root (), 'po', 'extra'),
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'desktop',
-    install_dir: join_paths(get_option('datadir'), 'applications'),
+    install_dir: get_option('datadir') / 'applications',
     install: true
 )
 

--- a/data/photos.desktop.in
+++ b/data/photos.desktop.in
@@ -1,13 +1,18 @@
 [Desktop Entry]
+Version=1.5
+Type=Application
+
 Name=Photos
 Comment=Organize your photos
-Exec=@EXEC_NAME@ %U
-Icon=io.elementary.photos
-GenericName=Photo Manager
-Keywords=album;cameras;crop;edit;enhance;export;gallery;images;import;organize;photographs;photos;pictures;photography;print;publish;rotate;share;tags;video;
-Terminal=false
-Type=Application
-StartupNotify=true
-MimeType=x-content/image-dcf;
 Categories=Graphics;Photography;GNOME;GTK;
+Keywords=album;cameras;crop;edit;enhance;export;gallery;images;import;organize;photographs;photos;pictures;photography;print;publish;rotate;share;tags;video;
+
+Icon=io.elementary.photos
+Exec=io.elementary.photos %U
+SingleMainWindow=true
+StartupNotify=true
+Terminal=false
+
+MimeType=x-content/image-dcf;
+
 X-GNOME-UsesNotifications=false

--- a/data/viewer.desktop.in
+++ b/data/viewer.desktop.in
@@ -1,11 +1,17 @@
 [Desktop Entry]
-Name=Photo Viewer
-GenericName=Photo Viewer
-Exec=@EXEC_NAME@ %U
-Icon=io.elementary.photos.viewer
-Terminal=false
-NoDisplay=true
+Version=1.5
 Type=Application
-StartupNotify=true
-MimeType=image/jpeg;image/jpg;image/pjpeg;image/png;image/tiff;image/gif;image/x-3fr;image/x-adobe-dng;image/x-arw;image/x-bay;image/x-bmp;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-pef;image/x-pentax-pef;image/x-png;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/webp;
+
+Name=Photo Viewer
 Categories=Graphics;Viewer;Photography;GNOME;GTK;
+
+Icon=io.elementary.photos.viewer
+Exec=io.elementary.photos %U
+NoDisplay=true
+SingleMainWindow=false
+StartupNotify=true
+Terminal=false
+
+MimeType=image/jpeg;image/jpg;image/pjpeg;image/png;image/tiff;image/gif;image/x-3fr;image/x-adobe-dng;image/x-arw;image/x-bay;image/x-bmp;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-pef;image/x-pentax-pef;image/x-png;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/webp;
+
+X-GNOME-UsesNotifications=false

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,3 +1,3 @@
-data/viewer.desktop.in.in
-data/io.elementary.photos.desktop.in.in
+data/viewer.desktop.in
+data/photos.desktop.in
 data/photos.metainfo.xml.in


### PR DESCRIPTION
* Don't set exec name using build system
* Add `SingleMainWindow` key
* Remove unused `GenericName` key