### PR TITLE
Make Photometadata class more robust

### DIFF
--- a/src/MediaMetadata.vala
+++ b/src/MediaMetadata.vala
@@ -44,7 +44,7 @@ public struct MetadataRational {
     }
 
     public bool is_valid () {
-        return (is_component_valid (numerator) && is_component_valid (denominator));
+        return (denominator > 0 && is_component_valid (numerator) && is_component_valid (denominator));
     }
 
     public string to_string () {

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -569,13 +569,12 @@ public class PhotoMetadata : MediaMetadata {
         try {
             if (exiv2.try_get_exif_tag_rational (tag, out numerator, out denominator)) {
                 rational = MetadataRational (numerator, denominator);
-                result = true;
             }
         } catch (Error e) {
             warning ("Error on getting tag %s rational in source %s. %s", tag, source_name, e.message);
         }
 
-        return result;
+        return rational.is_valid ();
     }
 
     public bool get_first_rational (string[] tags, out MetadataRational rational) {

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -555,28 +555,39 @@ public class PhotoMetadata : MediaMetadata {
 
     public bool get_rational (string tag, out MetadataRational rational) {
         int numerator, denominator;
-        bool result = exiv2.get_exif_tag_rational (tag, out numerator, out denominator);
+        bool result = false;
+        rational = MetadataRational (0, 0);
 
-        rational = MetadataRational (numerator, denominator);
+        try {
+            if (exiv2.try_get_exif_tag_rational (tag, out numerator, out denominator)) {
+                rational = MetadataRational (numerator, denominator);
+                result = true;
+            }
+        } catch (Error e) {
+            warning ("Error on getting tag %s rational in source %s. %s", tag, source_name, e.message);
+        }
 
         return result;
     }
 
     public bool get_first_rational (string[] tags, out MetadataRational rational) {
         foreach (string tag in tags) {
-            if (get_rational (tag, out rational))
+            if (get_rational (tag, out rational)) {
                 return true;
+            }
         }
 
         rational = MetadataRational (0, 0);
-
         return false;
     }
 
     public void set_rational (string tag, MetadataRational rational) {
-        if (!exiv2.set_exif_tag_rational (tag, rational.numerator, rational.denominator)) {
-            warning ("Unable to set tag %s to rational %s from source %s", tag, rational.to_string (),
-                     source_name);
+        try {
+            if (!exiv2.try_set_exif_tag_rational (tag, rational.numerator, rational.denominator)) {
+                warning ("Unable to set tag %s to rational %s from source %s", tag, rational.to_string (),source_name);
+            }
+        } catch (Error e) {
+            warning ("Error on setting tag %s rational in source %s. %s", tag, source_name, e.message);
         }
     }
 

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -318,7 +318,7 @@ public class PhotoMetadata : MediaMetadata {
         return collection;
     }
 
-    public Gee.Collection<string> get_all_tags (
+    public Gee.Collection<string>? get_all_tags (
         owned CompareDataFunc<string>? compare_func = null) {
         Gee.Collection<string> all_tags = create_string_set ((owned) compare_func);
 

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -588,7 +588,7 @@ public class PhotoMetadata : MediaMetadata {
         return false;
     }
 
-    public void set_rational (string tag, MetadataRational rational) {
+    public void set_rational (string tag, MetadataRational rational) requires (rational.is_valid ()) {
         try {
             if (!exiv2.try_set_exif_tag_rational (tag, rational.numerator, rational.denominator)) {
                 warning ("Unable to set tag %s to rational %s from source %s", tag, rational.to_string (), source_name);
@@ -598,7 +598,7 @@ public class PhotoMetadata : MediaMetadata {
         }
     }
 
-    public void set_all_rational (string[] tags, MetadataRational rational, SetOption option) {
+    public void set_all_rational (string[] tags, MetadataRational rational, SetOption option) requires (rational.is_valid ()) {
         set_all_generic (tags, option, (tag) => {
             set_rational (tag, rational);
         });

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -1098,17 +1098,19 @@ public class PhotoMetadata : MediaMetadata {
 
     public bool get_gps (out double longitude, out string long_ref, out double latitude, out string lat_ref,
                          out double altitude) {
-        if (!exiv2.get_gps_info (out longitude, out latitude, out altitude)) {
-            long_ref = null;
-            lat_ref = null;
 
-            return false;
-        }
+        long_ref = null;
+        lat_ref = null;
+        try {
+            if (exiv2.try_get_gps_info (out longitude, out latitude, out altitude)) {
+                long_ref = get_string ("Exif.GPSInfo.GPSLongitudeRef");
+                lat_ref = get_string ("Exif.GPSInfo.GPSLatitudeRef");
 
-        long_ref = get_string ("Exif.GPSInfo.GPSLongitudeRef");
-        lat_ref = get_string ("Exif.GPSInfo.GPSLatitudeRef");
+                return true;
+            }
+        } catch (Error e) {}
 
-        return true;
+        return false;
     }
 
     public bool get_exposure (out MetadataRational exposure) {

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -277,7 +277,11 @@ public class PhotoMetadata : MediaMetadata {
     }
 
     public bool has_tag (string tag) {
-        return exiv2.has_tag (tag);
+        try {
+            return exiv2.try_has_tag (tag);
+        } catch (Error e) {}
+
+        return false;
     }
 
     private Gee.Set<string> create_string_set (owned CompareDataFunc<string>? compare_func) {
@@ -444,7 +448,7 @@ public class PhotoMetadata : MediaMetadata {
         }
 
         try {
-            exiv2.set_tag_string (tag, prepped);
+            exiv2.try_set_tag_string (tag, prepped);
         } catch (Error e) {
             warning ("Unable to set tag %s to string %s from source %s - %s", tag, value, source_name, e.message);
         }
@@ -500,8 +504,13 @@ public class PhotoMetadata : MediaMetadata {
         // seen in the Flickr Connector as a result of the former bug.
         values += null;
 
-        if (!exiv2.set_tag_multiple (tag, values))
-            warning ("Unable to set %d strings to tag %s from source %s", values.length, tag, source_name);
+        try {
+            if (!exiv2.try_set_tag_multiple (tag, values)) {
+                warning ("Unable to set %d strings to tag %s from source %s", values.length, tag, source_name);
+            }
+        } catch (Error e) {
+                warning ("Error setting tag multiple on %s. %s", source_name, e.message);
+        }
     }
 
     public void set_all_string_multiple (string[] tags, Gee.Collection<string> values, SetOption option) {
@@ -584,7 +593,7 @@ public class PhotoMetadata : MediaMetadata {
     public void set_rational (string tag, MetadataRational rational) {
         try {
             if (!exiv2.try_set_exif_tag_rational (tag, rational.numerator, rational.denominator)) {
-                warning ("Unable to set tag %s to rational %s from source %s", tag, rational.to_string (),source_name);
+                warning ("Unable to set tag %s to rational %s from source %s", tag, rational.to_string (), source_name);
             }
         } catch (Error e) {
             warning ("Error on setting tag %s rational in source %s. %s", tag, source_name, e.message);

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -1067,18 +1067,6 @@ public class PhotoMetadata : MediaMetadata {
         return h_keywords;
     }
 
-    // Returns whether the image has orientation information in the metadata
-    public bool has_orientation () {
-        try {
-            var result = exiv2.try_get_orientation ();
-            return result != GExiv2.Orientation.UNSPECIFIED;
-        } catch (Error e) {
-            warning ("Exiv2 error getting has orientation from source %s. %s", source_name, e.message);
-        }
-
-        return false;
-    }
-
     // If not present, returns Orientation.TOP_LEFT.
     public Orientation get_orientation () {
         // GExiv2.Orientation is the same value-wise as Orientation, with one exception:

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -183,10 +183,9 @@ public class PhotoMetadata : MediaMetadata {
     }
 
     public void read_from_buffer (uint8[] buffer, int length = 0) throws Error {
-        if (length <= 0)
+        if (length <= 0 || length > buffer.length) {
             length = buffer.length;
-
-        assert (buffer.length >= length);
+        }
 
         exiv2 = new GExiv2.Metadata ();
         exif = null;

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -145,7 +145,6 @@ public class PhotoMetadata : MediaMetadata {
         public override Bytes flatten () throws Error {
             // owner and exiv2 are initialized on construction so can be assumed non-null
             unowned GExiv2.PreviewProperties?[] props = owner.exiv2.get_preview_properties ();
-            // assert (props != null && props.length > number);
             if (props == null) {
                 critical ("InternalPhotoPreview.flatten () - null preview properties");
                 throw new PhotoMetadataError.MISSING_DATA ("preview properties missing");
@@ -156,7 +155,6 @@ public class PhotoMetadata : MediaMetadata {
                 throw new PhotoMetadataError.MISSING_DATA ("Too few preview properties. Expected > %u, got %u", number, props.length);
             }
 
-            // GExiv2.MetaData.get_preview_image is deprecated since 014
             var preview_image = owner.exiv2.try_get_preview_image (props[number]).get_data (); // Throws Error
             return new Bytes (preview_image);
         }

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -143,11 +143,7 @@ public class PhotoMetadata : MediaMetadata {
         }
 
         public override Bytes flatten () throws Error {
-            if (owner.exiv2 == null) {
-                critical ("InternalPhotoPreview.flatten () called with null owner.exiv2");
-                throw new PhotoMetadataError.MISSING_DATA ("exiv2 data missing");
-            }
-
+            // owner and exiv2 are initialized on construction so can be assumed non-null
             unowned GExiv2.PreviewProperties?[] props = owner.exiv2.get_preview_properties ();
             // assert (props != null && props.length > number);
             if (props == null) {

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -511,13 +511,17 @@ public class PhotoMetadata : MediaMetadata {
     }
 
     public bool get_long (string tag, out long value) {
-        if (!has_tag (tag)) {
-            value = 0;
+        value = 0;
+        try {
+            if (!has_tag (tag)) {
+                return false;
+            }
 
+            value = exiv2.try_get_tag_long (tag);
+        } catch (Error e) {
+            warning ("Failed to get tag long from source %s. %s", source_name, e.message);
             return false;
         }
-
-        value = exiv2.get_tag_long (tag);
 
         return true;
     }
@@ -534,8 +538,13 @@ public class PhotoMetadata : MediaMetadata {
     }
 
     public void set_long (string tag, long value) {
-        if (!exiv2.set_tag_long (tag, value))
+        try {
+        if (!exiv2.try_set_tag_long (tag, value)) {
             warning ("Unable to set tag %s to long %ld from source %s", tag, value, source_name);
+        }
+        } catch (Error e) {
+            warning ("Error on setting tag %s long in source %s. %s", tag, source_name, e.message);
+        }
     }
 
     public void set_all_long (string[] tags, long value, SetOption option) {


### PR DESCRIPTION
May fix some issues with loading corrupt metadata.

 - Replaces an assert statement with throwing errors
 - Replaces deprecated GExiv2 methods with new error throwing ones and handle errors where necessary