### PR TITLE
Make MetadataWriter more robust

### DIFF
--- a/src/DirectoryMonitor.vala
+++ b/src/DirectoryMonitor.vala
@@ -925,7 +925,7 @@ public class DirectoryMonitor : Object {
                 foreach (FileInfo info in infos) {
                     // we don't deal with hidden files or directories
                     if (info.get_is_hidden ()) {
-                        warning ("Skipping hidden file/directory %s",
+                        debug ("Skipping hidden file/directory %s",
                                  dir.get_child (info.get_name ()).get_path ());
 
                         continue;

--- a/src/LibraryMonitor.vala
+++ b/src/LibraryMonitor.vala
@@ -742,14 +742,22 @@ public class LibraryMonitor : DirectoryMonitor {
     //
     // Use of this method should be avoided at all costs (otherwise the point of the real-time
     // monitor is negated).
-    public static void blacklist_file (File file, string reason) {
+    public static void blacklist_file (File? file, string reason) {
+        if (file == null) {
+            return;
+        }
+
         mdbg ("[%s] Blacklisting %s".printf (reason, file.get_path ()));
         lock (blacklist) {
             blacklist.add (file);
         }
     }
 
-    public static void unblacklist_file (File file) {
+    public static void unblacklist_file (File? file) {
+        if (file == null) {
+            return;
+        }
+
         // don't want to immediately remove the blacklisted file because the monitoring events
         // can come in much later
         lock (blacklist) {

--- a/src/MetadataWriter.vala
+++ b/src/MetadataWriter.vala
@@ -74,23 +74,18 @@ public class MetadataWriter : Object {
         }
 
         private void commit_editable () throws Error {
-            if (!photo.has_editable () || !photo.get_editable_file_format ().can_write_metadata ())
-                return;
-
             PhotoMetadata? metadata = photo.get_editable_metadata ();
-            assert (metadata != null);
-
-            if (update_metadata (metadata)) {
-                LibraryMonitor.blacklist_file (photo.get_editable_file (), "MetadataWriter.commit_editable");
-                try {
-                    photo.persist_editable_metadata (metadata, out reimport_editable_state);
-                } finally {
-                    LibraryMonitor.unblacklist_file (photo.get_editable_file ());
-                }
+            if (update_metadata (metadata)) { // null safe
+                // Photo does necessary checks and may throw error
+                photo.persist_editable_metadata (metadata, out reimport_editable_state);
             }
         }
 
-        private bool update_metadata (PhotoMetadata metadata, bool skip_orientation = false) {
+        private bool update_metadata (PhotoMetadata? metadata, bool skip_orientation = false) {
+            if (metadata == null) {
+                return false;
+            }
+
             bool changed = false;
 
             // title (caption)

--- a/src/MetadataWriter.vala
+++ b/src/MetadataWriter.vala
@@ -33,8 +33,8 @@ public class MetadataWriter : Object {
     private class CommitJob : BackgroundJob {
         public LibraryPhoto photo;
         public Gee.Set<string>? current_keywords;
-        public Photo.ReimportMasterState reimport_master_state = null;
-        public Photo.ReimportEditableState reimport_editable_state = null;
+        public Photo.ReimportMasterState? reimport_master_state = null;
+        public Photo.ReimportEditableState? reimport_editable_state = null;
         public Error? err = null;
 
         public CommitJob (MetadataWriter owner, LibraryPhoto photo, Gee.Set<string>? keywords) {

--- a/src/MetadataWriter.vala
+++ b/src/MetadataWriter.vala
@@ -58,24 +58,16 @@ public class MetadataWriter : Object {
             // otherwise, we'll end up ruining the original, and as such, breaking the
             // ability to revert to it.
             bool skip_orientation = photo.has_editable ();
-
-            if (!photo.get_master_file_format ().can_write_metadata ())
-                return;
-
             PhotoMetadata metadata = photo.get_master_metadata ();
             if (update_metadata (metadata, skip_orientation)) {
-                LibraryMonitor.blacklist_file (photo.get_master_file (), "MetadataWriter.commit_master");
-                try {
-                    photo.persist_master_metadata (metadata, out reimport_master_state);
-                } finally {
-                    LibraryMonitor.unblacklist_file (photo.get_master_file ());
-                }
+                // Photo does necessary checks and may throw error
+                photo.persist_master_metadata (metadata, out reimport_master_state);
             }
         }
 
         private void commit_editable () throws Error {
             PhotoMetadata? metadata = photo.get_editable_metadata ();
-            if (update_metadata (metadata)) { // null safe
+            if (update_metadata (metadata)) {
                 // Photo does necessary checks and may throw error
                 photo.persist_editable_metadata (metadata, out reimport_editable_state);
             }

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -248,7 +248,7 @@ public abstract class Photo : PhotoSource, Dateable {
     private PixelTransformer transformer = null;
     private PixelTransformationBundle adjustments = null;
     // because file_title is determined by data in row, it should only be accessed when row is locked
-    private string file_title = null;
+    private string file_title = "";
     private FileMonitor editable_monitor = null;
     private OneShotScheduler reimport_editable_scheduler = null;
     private OneShotScheduler update_editable_attributes_scheduler = null;

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -2703,7 +2703,7 @@ public abstract class Photo : PhotoSource, Dateable {
                 e.message
             );
         } finally {
-            LibraryMonitor.unblacklist_file (photo.get_master_file ());
+            LibraryMonitor.unblacklist_file (master_file);
         }
 
         if (!prepare_for_reimport_master (out state)) {

--- a/src/Photo.vala
+++ b/src/Photo.vala
@@ -1336,7 +1336,7 @@ public abstract class Photo : PhotoSource, Dateable {
 
     // This method is thread-safe.  If returns false the photo should be marked offline (in the
     // main UI thread).
-    public bool prepare_for_reimport_master (out ReimportMasterState reimport_state) throws Error {
+    public bool prepare_for_reimport_master (out ReimportMasterState? reimport_state) throws Error {
         reimport_state = null;
 
         File file = get_master_reader ().get_file ();
@@ -1418,7 +1418,12 @@ public abstract class Photo : PhotoSource, Dateable {
     protected abstract void apply_user_metadata_for_reimport (PhotoMetadata metadata);
 
     // This method is not thread-safe and should be called in the main thread.
-    public void finish_reimport_master (ReimportMasterState state) throws DatabaseError {
+    public void finish_reimport_master (ReimportMasterState? state) throws DatabaseError {
+        if (state == null) {
+            warning ("finish_reimport_state called with null state - ignoring");
+            return;
+        }
+
         ReimportMasterStateImpl reimport_state = (ReimportMasterStateImpl) state;
 
         PhotoTable.get_instance ().reimport (reimport_state.row);
@@ -1460,9 +1465,10 @@ public abstract class Photo : PhotoSource, Dateable {
         }
     }
 
-    // Verifies a file for reimport.  Returns the file's detected photo info.
+    // Verifies a (non null) file for reimport.  Returns the file's detected photo info.
     private bool verify_file_for_reimport (File file, out BackingPhotoRow backing,
                                            out DetectedPhotoInformation detected) throws Error {
+
         backing = query_backing_photo_row (file, PhotoFileSniffer.Options.NO_MD5,
         out detected);
         if (backing == null) {
@@ -1504,7 +1510,7 @@ public abstract class Photo : PhotoSource, Dateable {
     // This method is not thread-safe.  It should be called by the main thread.
     public void finish_reimport_editable (ReimportEditableState state) throws DatabaseError {
         BackingPhotoID editable_id = get_editable_id ();
-        if (editable_id.is_invalid ()) {
+        if (state == null || editable_id.is_invalid ()) {
             return;
         }
 

--- a/src/photos/PhotoFileFormat.vala
+++ b/src/photos/PhotoFileFormat.vala
@@ -112,6 +112,7 @@ public enum PhotoFileFormat {
             return UNKNOWN;
 
         foreach (PhotoFileFormat file_format in get_supported ()) {
+            // Supported formats must have driver with properties
             if (file_format.get_driver ().get_properties ().is_recognized_extension (ext))
                 return file_format;
         }
@@ -399,7 +400,7 @@ public abstract class PhotoFileFormatDriver {
 
     public abstract PhotoFileWriter? create_writer (string filepath);
 
-    public abstract PhotoFileMetadataWriter? create_metadata_writer (string filepath);
+    public abstract PhotoFileMetadataWriter? create_metadata_writer (string filepath);  // Note can be null
 
     public abstract PhotoFileSniffer create_sniffer (File file, PhotoFileSniffer.Options options);
 }

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -41,6 +41,11 @@ public enum MetadataDomain {
     IPTC
 }
 
+errordomain PhotoMetadataError {
+    MISSING_DATA,
+    UNKNOWN_ERROR
+}
+
 public class HierarchicalKeywordField {
     public string field_name;
     public string path_separator;


### PR DESCRIPTION
 - Add some null checks
 - Remove asserts and replace with critical messages

The codebase contains a *lot* of places where the app just terminates due to an assertion failure.  This does not seem necessary for production code and these have been replaced with critical messages and the subsequent code either omitted or continued as seems appropriate.  If reviewers feel an assertion failure would cause user data corruption on continued use then it should be replaced with a call to AppWindow.panic which at least logs a message before terminating.

There were a few places where a null could theoretically be dereferences. It is difficult to know whether this occurs in practice as the code is extremely convoluted.