### PR TITLE
MetadataDateTime: Fix crash in fallback scanf code

### DIFF
--- a/src/MediaMetadata.vala
+++ b/src/MediaMetadata.vala
@@ -102,12 +102,12 @@ public class MetadataDateTime {
         int second = 0;
 
         if (date_time_s.scanf ("%d:%d:%d %d:%d:%d",
-                             &year, &month, &day, &hour, &minute, &second) != 6) {
+                             out year, out month, out day, out hour, out minute, out second) != 6) {
             // Fallback in a more generic format
             string tmp = date_time_s.dup ();
             tmp.canon ("0123456789", ' ');
             if (tmp.scanf ("%4d%2d%2d%2d%2d%2d",
-                           year, month, day, hour, minute, second) != 6) {
+                           out year, out month, out day, out hour, out minute, out second) != 6) {
                 return false;
             }
         }


### PR DESCRIPTION
Fixes #641 

There was a coding error in the use of the `string.scanf` function in the fallback code - the `out` parameters were not correctly supplied.  

The same error was not made in the "normal" code path so it only occurs if an image has a non-standard/corrupt date-time tag.  Presumably this is rare.

The opportunity is taken to write both functions in `Vala` style rather than `C` style (i.e. using the `out` keyword).