### PR TITLE
DirectoryMonitor: Silence hidden file terminal warning

### DIFF
--- a/src/DirectoryMonitor.vala
+++ b/src/DirectoryMonitor.vala
@@ -878,7 +878,7 @@ public class DirectoryMonitor : Object {
         }
 
         if (local_dir_info.get_is_hidden ()) {
-            warning ("Ignoring hidden directory %s", dir.get_path ());
+            debug ("Ignoring hidden directory %s", dir.get_path ());
 
             explore_directory_completed (in_discovery);
 
@@ -925,7 +925,7 @@ public class DirectoryMonitor : Object {
                 foreach (FileInfo info in infos) {
                     // we don't deal with hidden files or directories
                     if (info.get_is_hidden ()) {
-                        warning ("Skipping hidden file/directory %s",
+                        debug ("Skipping hidden file/directory %s",
                                  dir.get_child (info.get_name ()).get_path ());
 
                         continue;


### PR DESCRIPTION
There is no need to have a terminal warning about skipping hidden files - this is normal program behaviour.