### PR TITLE
Fix panning zoomed images on Wayland

### DIFF
--- a/src/Views/SinglePhotoPage.vala
+++ b/src/Views/SinglePhotoPage.vala
@@ -151,6 +151,7 @@ public abstract class SinglePhotoPage : Page {
         canvas_ctx.set_source_surface (pixmap, 0, 0);
         canvas_ctx.paint ();
         canvas_ctx.restore ();
+        queue_draw ();
     }
 
     protected virtual bool is_zoom_supported () {


### PR DESCRIPTION
Fixes #789 

This fixes the issue on Wayland OS8.