### PR TITLE
Resource: add path to symbolics

### DIFF
--- a/data/icons/icons.gresource.xml
+++ b/data/icons/icons.gresource.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/io/elementary/photos/icons">
-    <file alias="aperture-symbolic.svg" compressed="true" preprocess="xml-stripblanks">aperture-symbolic.svg</file>
     <file alias="drag-nub.svg" compressed="true"  preprocess="xml-stripblanks">drag-nub.svg</file>
     <file alias="edit-flag.svg" compressed="true" preprocess="xml-stripblanks">edit-flag.svg</file>
-    <file alias="exposure-bias-symbolic.svg" compressed="true" preprocess="xml-stripblanks">exposure-bias-symbolic.svg</file>
-    <file alias="exposure-symbolic.svg" compressed="true" preprocess="xml-stripblanks">exposure-symbolic.svg</file>
-    <file alias="flash-symbolic.svg" compressed="true" preprocess="xml-stripblanks">flash-symbolic.svg</file>
-    <file alias="focal-length-symbolic.svg" compressed="true" preprocess="xml-stripblanks">focal-length-symbolic.svg</file>
     <file alias="image-adjust.svg" compressed="true" preprocess="xml-stripblanks">image-adjust.svg</file>
     <file alias="image-auto-adjust.svg" compressed="true" preprocess="xml-stripblanks">image-auto-adjust.svg</file>
     <file alias="image-crop.svg" compressed="true" preprocess="xml-stripblanks">image-crop.svg</file>
     <file alias="image-red-eye.svg" compressed="true" preprocess="xml-stripblanks">image-red-eye.svg</file>
-    <file alias="iso-symbolic.svg" compressed="true" preprocess="xml-stripblanks">iso-symbolic.svg</file>
     <file alias="object-straighten.svg" compressed="true" preprocess="xml-stripblanks">object-straighten.svg</file>
+
+    <file alias="scalable/actions/view-pin-symbolic.svg" compressed="true" preprocess="xml-stripblanks">view-pin-symbolic.svg</file>
+
+    <file alias="scalable/categories/aperture-symbolic.svg" compressed="true" preprocess="xml-stripblanks">aperture-symbolic.svg</file>
+    <file alias="scalable/categories/exposure-bias-symbolic.svg" compressed="true" preprocess="xml-stripblanks">exposure-bias-symbolic.svg</file>
+    <file alias="scalable/categories/exposure-symbolic.svg" compressed="true" preprocess="xml-stripblanks">exposure-symbolic.svg</file>
+    <file alias="scalable/categories/flash-symbolic.svg" compressed="true" preprocess="xml-stripblanks">flash-symbolic.svg</file>
+    <file alias="scalable/categories/focal-length-symbolic.svg" compressed="true" preprocess="xml-stripblanks">focal-length-symbolic.svg</file>
+    <file alias="scalable/categories/iso-symbolic.svg" compressed="true" preprocess="xml-stripblanks">iso-symbolic.svg</file>
   </gresource>
   <gresource prefix="/io/elementary/photos/backgrounds">
     <file alias="noninterpretable-video.svg" compressed="true" preprocess="xml-stripblanks">noninterpretable-video.svg</file>

--- a/data/icons/view-pin-symbolic.svg
+++ b/data/icons/view-pin-symbolic.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     transform="translate(-813 -69)"
+     id="g1"
+     style="fill:#555761">
+    <path
+       color="#000"
+       d="M814 72.772c-.554 0-1 .446-1 1v5.494c0 .554.446 1 1 1s1-.446 1-1l3.25-.282A4.5 4.5 0 0 0 822 81v-4h4l2-.5-2-.5h-4v-4a4.5 4.5 0 0 0-3.683 1.924L815 73.772c0-.554-.446-1-1-1z"
+       fill="#666"
+       overflow="visible"
+       style="isolation:auto;mix-blend-mode:normal;marker:none;fill:#555761"
+       id="path1" />
+  </g>
+</svg>


### PR DESCRIPTION
Symbolic icons need to have a path in Gtk4 to work correctly. While we're here, add missing non-fd.o `view-pin-symbolic`