### PR TITLE
Add support for gexiv2-0.16

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,9 +45,10 @@ i18n = import('i18n')
 glib_dep = dependency('glib-2.0', version: '>=2.30.0')
 gio_unix_dep = dependency('gio-unix-2.0', version: '>=2.20')
 gee_dep = dependency('gee-0.8', version: '>=0.8.5')
-gexiv2_dep = dependency('gexiv2', version: '>=0.4.90')
-if gexiv2_dep.version().version_compare('>= 0.11')
-  add_global_arguments(['--define=GEXIV2_0_11'], language : 'vala')
+# gexiv2 adopts API versioning since 0.15.0
+gexiv2_dep = dependency('gexiv2-0.16', required: false)
+if not gexiv2_dep.found()
+    gexiv2_dep = dependency('gexiv2', version: '>=0.12.2')
 endif
 geocode_glib_dep = dependency('geocode-glib-2.0', 'geocode-glib-1.0')
 gmodule_dep = dependency('gmodule-2.0', version: '>=2.24.0')

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -339,8 +339,8 @@ public class PhotoMetadata : MediaMetadata {
         return GExiv2.Metadata.get_tag_label (tag);
     }
 
-    public string? get_tag_description (string tag) {
-        return GExiv2.Metadata.get_tag_description (tag);
+    public string? try_get_tag_description (string tag) throws Error {
+        return GExiv2.Metadata.try_get_tag_description (tag);
     }
 
     public string? get_string (string tag, PrepareInputTextOptions options = PREPARE_STRING_OPTIONS) {


### PR DESCRIPTION
Required for #809

- Add support for gexiv2-0.16
    - It now adopts API versioning: https://gitlab.gnome.org/GNOME/gexiv2/-/releases/0.15.0
    - Replace `GExiv2.Metadata.get_tag_description ()` which was deprecated in 0.12.2 and removed in gexiv2-0.16 with `GExiv2.Metadata.try_get_tag_description ()`
        - Drop support for gexiv2 < 0.12.2
- Remove unused `GEXIV2_0_11` which was leftover from bc7feca8caa4c8fc076a759a2d36e26e93c75596
