### PR TITLE
VideoSupport: Replace deprecated Gst.PbUtils.DiscovererInfo.get_tags

### DIFF
--- a/src/VideoSupport.vala
+++ b/src/VideoSupport.vala
@@ -205,6 +205,7 @@ public class VideoReader {
         try {
             Gst.PbUtils.Discoverer d = new Gst.PbUtils.Discoverer ((Gst.ClockTime) (Gst.SECOND * 5));
             Gst.PbUtils.DiscovererInfo info = d.discover_uri (file.get_uri ());
+            Gst.PbUtils.DiscovererStreamInfo stream_info = info.get_stream_info ();
 
             clip_duration = ((double) info.get_duration ()) / 1000000000.0;
             timestamp = new DateTime.now_local ().to_unix (); // Fallback to now
@@ -212,7 +213,7 @@ public class VideoReader {
             // TODO: Note that TAG_DATE can be changed to TAG_DATE_TIME in the future
             // (and the corresponding output struct) in order to implement #2836.
             Gst.DateTime? video_date = null;
-            if (info.get_tags () != null && info.get_tags ().get_date_time (Gst.Tags.DATE, out video_date)) {
+            if (stream_info.get_tags () != null && stream_info.get_tags ().get_date_time (Gst.Tags.DATE, out video_date)) {
                 if (video_date != null) {
                     var g_date_time = video_date.to_g_date_time ();
                     if (g_date_time != null) {


### PR DESCRIPTION
Fixes the following build warning:

```
../src/VideoSupport.vala:215.17-215.29: warning: `Gst.PbUtils.DiscovererInfo.get_tags' has been deprecated since 1.20
  215 |             if (info.get_tags () != null && info.get_tags ().get_date_time (Gst.Tags.DATE, out video_date)) {
      |                 ^~~~~~~~~~~~~                                                                                
../src/VideoSupport.vala:215.45-215.57: warning: `Gst.PbUtils.DiscovererInfo.get_tags' has been deprecated since 1.20
  215 |             if (info.get_tags () != null && info.get_tags ().get_date_time (Gst.Tags.DATE, out video_date)) {
      |                                             ^~~~~~~~~~~~~                                                    
```

The solution here is just what https://gstreamer.freedesktop.org/releases/1.20/ says:

> `gst_discoverer_container_info_get_tags()` was added to retrieve global/container tags (vs. per-stream tags). Per-Stream tags can be retrieved via the existing `gst_discoverer_stream_info_get_tags()`. `gst_discoverer_info_get_tags()`, which for many files returns a confusing mix of stream and container tags, has been deprecated in favour of the container/stream-specific functions.
