### PR TITLE
PhotoMetadata: Replace deprecated GExiv2.Metadata.get_tag_label

### DIFF
--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -1708,7 +1708,16 @@ public abstract class EditingHostPage : SinglePhotoPage {
                 if (tags != null) {
                     var ts = new Gee.TreeSet<string> ();
                     foreach (var s in tags) {
-                        ts.add ("%s: %s".printf (metadata.get_tag_label (s), metadata.get_string_interpreted (s)));
+                        string tag_label;
+
+                        try {
+                            tag_label = metadata.try_get_tag_label (s);
+                        } catch (Error err) {
+                            warning ("Failed to get tag label: tag=%s", s);
+                            continue;
+                        }
+
+                        ts.add ("%s: %s".printf (tag_label, metadata.get_string_interpreted (s)));
                     }
 
                     foreach (var s in ts) {

--- a/src/photos/PhotoMetadata.vala
+++ b/src/photos/PhotoMetadata.vala
@@ -335,8 +335,8 @@ public class PhotoMetadata : MediaMetadata {
         return all_tags.size > 0 ? all_tags : null;
     }
 
-    public string? get_tag_label (string tag) {
-        return GExiv2.Metadata.get_tag_label (tag);
+    public string? try_get_tag_label (string tag) throws Error {
+        return GExiv2.Metadata.try_get_tag_label (tag);
     }
 
     public string? try_get_tag_description (string tag) throws Error {


### PR DESCRIPTION
Fixes the following build warning:

```
../src/photos/PhotoMetadata.vala:339.16-339.44: warning: `GExiv2.Metadata.get_tag_label' has been deprecated since 0.12.2
  339 |         return GExiv2.Metadata.get_tag_label (tag);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~       
```

The solution here is to use the alternative method that [valadoc](https://valadoc.org/gexiv2/GExiv2.Metadata.get_tag_label.html) says.
