### PR TITLE
Page: Replace deprecated Gdk.Keymap.get_default

### DIFF
--- a/src/Views/Page.vala
+++ b/src/Views/Page.vala
@@ -746,7 +746,14 @@ public abstract class Page : Gtk.ScrolledWindow {
     protected bool match_keycode (int keyval, uint code) {
 #endif
         Gdk.KeymapKey [] keys;
-        Gdk.Keymap keymap = Gdk.Keymap.get_default ();
+
+        Gdk.Display? default_display = Gdk.Display.get_default ();
+        if (default_display == null) {
+            warning ("Failed to get default display");
+            return false;
+        }
+
+        Gdk.Keymap keymap = Gdk.Keymap.get_for_display (default_display);
         if (keymap.get_entries_for_keyval (keyval, out keys)) {
             foreach (var key in keys) {
                 if (code == key.keycode)


### PR DESCRIPTION
Fixes the following build warning:

```
../src/Views/Page.vala:749.29-749.50: warning: `Gdk.Keymap.get_default' has been deprecated since 3.22
  749 |         Gdk.Keymap keymap = Gdk.Keymap.get_default ();
      |                             ^~~~~~~~~~~~~~~~~~~~~~    
```

The solution here is to use the alternative method that [valadoc](https://valadoc.org/gdk-3.0/Gdk.Keymap.get_default.html) says.
