### PR TITLE
Plugins: Replace deprecated ModuleFlags.BIND_LAZY and Module.SUFFIX

### DIFF
--- a/src/plugins/Plugins.vala
+++ b/src/plugins/Plugins.vala
@@ -60,7 +60,7 @@ private class ModuleRep {
 
     private ModuleRep (File file) {
         this.file = file;
-        module = Module.open (file.get_path (), ModuleFlags.BIND_LAZY);
+        module = Module.open (file.get_path (), ModuleFlags.LAZY);
     }
 
     ~ModuleRep () {
@@ -347,16 +347,15 @@ public int compare_extension_point_names (ExtensionPoint a, ExtensionPoint b) {
 }
 
 private bool is_shared_library (File file) {
-    var basename = file.get_basename ();
-    if (basename == null) {
+    // Module.open() searches the filesystem for combinations of possible
+    // suffixes and prefixes and fails if the given file is not a shared library
+    Module? module = Module.open (file.get_path (), ModuleFlags.LAZY);
+    if (module == null) {
         return false;
     }
 
-    if (GLib.Module.SUFFIX in basename) {
-        return true;
-    }
-
-    return false;
+    module.close ();
+    return true;
 }
 
 private void search_for_plugins (File dir) throws Error {


### PR DESCRIPTION
Fixes the following build warning:

```
../src/plugins/Plugins.vala:63.49-63.69: warning: `GLib.ModuleFlags.BIND_LAZY' has been deprecated since vala-0.46. Use LAZY
   63 |         module = Module.open (file.get_path (), ModuleFlags.BIND_LAZY);
      |                                                 ^~~~~~~~~~~~~~~~~~~~~  

../src/plugins/Plugins.vala:355.9-355.26: warning: `GLib.Module.SUFFIX' has been deprecated since 2.76
  355 |     if (GLib.Module.SUFFIX in basename) {
      |         ^~~~~~~~~~~~~~~~~~               
```

The solution for ModuleFlags.BIND_LAZY is to use the alternative method that [valadoc](https://valadoc.org/gmodule-2.0/GLib.ModuleFlags.BIND_LAZY.html) says.

Regarding to Module.SUFFIX, valadoc says nothing about alternative, but there are some hints in the original C source code:

https://gitlab.gnome.org/GNOME/glib/-/blob/2.80.0/gmodule/gmodule.c?ref_type=tags#L87-108
https://gitlab.gnome.org/GNOME/glib/-/blob/2.80.0/gmodule/gmodule.c?ref_type=tags#L429-464
