### PR TITLE
meson: Use multiple dependency name instead of manual fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ You'll need the following dependencies:
 * libexif-dev
 * libgee-0.8-dev
 * libgeocode-glib-dev
-* libgexiv2-dev
-* libglib2.0-dev
+* libgexiv2-dev >= 0.12.2
+* libglib2.0-dev >= 2.76.0
 * libgphoto2-dev
 * libgranite-dev >= 6.0.0
 * libgstreamer1.0-dev
@@ -26,7 +26,7 @@ You'll need the following dependencies:
 * libraw-dev
 * libsqlite3-dev
 * libwebp-dev
-* meson >= 0.57.0
+* meson >= 0.60.0
 * valac >= 0.40
 
 Run `meson build` to configure the build environment. Change to the build directory and run `ninja` to build

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'io.elementary.photos',
     'vala', 'c',
     version: '8.0.1',
-    meson_version: '>=0.57.0'
+    meson_version: '>=0.60.0'
 )
 
 add_project_arguments([
@@ -46,12 +46,9 @@ glib_dep = dependency('glib-2.0', version: '>=2.30.0')
 gio_unix_dep = dependency('gio-unix-2.0', version: '>=2.20')
 gee_dep = dependency('gee-0.8', version: '>=0.8.5')
 # gexiv2 adopts API versioning since 0.15.0
-gexiv2_dep = dependency('gexiv2-0.16', required: false)
-if not gexiv2_dep.found()
-    gexiv2_dep = dependency('gexiv2', version: '>=0.12.2')
-endif
+gexiv2_dep = dependency('gexiv2-0.16', 'gexiv2', version: '>=0.12.2')
 geocode_glib_dep = dependency('geocode-glib-2.0', 'geocode-glib-1.0')
-gmodule_dep = dependency('gmodule-2.0', version: '>=2.24.0')
+gmodule_dep = dependency('gmodule-2.0', version: '>=2.76.0')
 gstreamer_dep = dependency('gstreamer-1.0', version: '>=1.0.0')
 gstreamer_base_dep = dependency('gstreamer-base-1.0', version: '>=1.0.0')
 gstreamer_plugins_base_dep = dependency('gstreamer-plugins-base-1.0', version: '>=1.0.0')


### PR DESCRIPTION
Use the feature of meson instead of handling fallback manually. From https://mesonbuild.com/Reference-manual_functions.html#dependency:

> Since 0.60.0 more than one name can be provided, they will be tried in order and the first name to be found will be used.

Also update README and meson.build to apply recent version limitation changes in #810 and #817
