### PR TITLE
Rename RDNN to io.elementary.contractor

### DIFF
--- a/io.elementary.photos.json
+++ b/io.elementary.photos.json
@@ -13,7 +13,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
-        "--talk-name=org.elementary.Contractor",
+        "--talk-name=io.elementary.Contractor",
         "--metadata=X-Dconf=migrate-path=/io/elementary/photos/"
     ],
     "cleanup": [


### PR DESCRIPTION
In discussions https://github.com/elementary/contractor/pull/31 and https://github.com/elementary/contractor/pull/41, @ryonakano pointed out the need to transition from `org.elementary.Contractor` to `io.elementary.Contractor` as part of the RDNN rename for OS 9

This PR updates the occurrences in `io.elementary.calendar.yml` to match the changes in the Contractor daemon

Note: This change is part of a cross-repo transition and should be merged in coordination with the Contractor PR

I did the same work in https://github.com/elementary/code/pull/1686 and https://github.com/elementary/granite/pull/943#pullrequestreview-3724378310, today I'm gonna to finish the leaving renames (today is 30th of January for me)