### PR TITLE
Split rotate left and right buttons

### DIFF
--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -78,7 +78,7 @@ public const string ICON_FLAGGED_PAGE = "edit-flag";
 
 public const string ROTATE_CW_MENU = _("Rotate _Right");
 public const string ROTATE_CW_FULL_LABEL = _("Rotate Right");
-public const string ROTATE_CW_TOOLTIP = _("Rotate the photos right (press Ctrl to rotate left)");
+public const string ROTATE_CW_TOOLTIP = _("Rotate the photos right");
 
 public const string ROTATE_CCW_MENU = _("Rotate _Left");
 public const string ROTATE_CCW_FULL_LABEL = _("Rotate Left");

--- a/src/Views/CollectionPage.vala
+++ b/src/Views/CollectionPage.vala
@@ -45,7 +45,8 @@ public abstract class CollectionPage : MediaPage {
     private Gtk.ToggleButton? enhance_button = null;
     private Gtk.Menu item_context_menu;
     private Gtk.Menu contractor_submenu;
-    private Gtk.Button rotate_button;
+    private Gtk.Button rotate_left_button;
+    private Gtk.Button rotate_right_button;
     private Gtk.Button flip_button;
 
     protected CollectionPage (string page_name) {
@@ -68,12 +69,19 @@ public abstract class CollectionPage : MediaPage {
         slideshow_button.tooltip_text = _("Play a slideshow");
         slideshow_button.clicked.connect (on_slideshow);
 
-        rotate_button = new Gtk.Button.from_icon_name (Resources.CLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
-        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP; // Will be used be screen reader if no label
-        rotate_button.clicked.connect (on_rotate_clockwise);
+        rotate_left_button = new Gtk.Button.from_icon_name (Resources.COUNTERCLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
+        rotate_left_button.tooltip_text = Resources.ROTATE_CCW_TOOLTIP; // Will be used be screen reader if no label
+        rotate_left_button.clicked.connect (on_rotate_counterclockwise);
 
-        var rotate_action = get_action ("RotateClockwise");
-        rotate_action.bind_property ("sensitive", rotate_button, "sensitive", BindingFlags.SYNC_CREATE);
+        var rotate_left_action = get_action ("RotateCounterclockwise");
+        rotate_left_action.bind_property ("sensitive", rotate_left_button, "sensitive", BindingFlags.SYNC_CREATE);
+
+        rotate_right_button = new Gtk.Button.from_icon_name (Resources.CLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
+        rotate_right_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP; // Will be used be screen reader if no label
+        rotate_right_button.clicked.connect (on_rotate_clockwise);
+
+        var rotate_right_action = get_action ("RotateClockwise");
+        rotate_right_action.bind_property ("sensitive", rotate_right_button, "sensitive", BindingFlags.SYNC_CREATE);
 
         flip_button = new Gtk.Button.from_icon_name (Resources.HFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
@@ -97,7 +105,8 @@ public abstract class CollectionPage : MediaPage {
         show_sidebar_button.clicked.connect (on_show_sidebar);
 
         toolbar.pack_start (slideshow_button);
-        toolbar.pack_start (rotate_button);
+        toolbar.pack_start (rotate_left_button);
+        toolbar.pack_start (rotate_right_button);
         toolbar.pack_start (flip_button);
         toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         toolbar.pack_start (enhance_button);
@@ -839,12 +848,8 @@ public abstract class CollectionPage : MediaPage {
     protected override bool on_ctrl_pressed (Gdk.EventKey? event) {
         flip_button.image = new Gtk.Image.from_icon_name (Resources.VFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.VFLIP_TOOLTIP;
-        rotate_button.image = new Gtk.Image.from_icon_name (Resources.COUNTERCLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
-        rotate_button.tooltip_text = Resources.ROTATE_CCW_TOOLTIP;
         flip_button.clicked.disconnect (on_flip_horizontally);
         flip_button.clicked.connect (on_flip_vertically);
-        rotate_button.clicked.disconnect (on_rotate_clockwise);
-        rotate_button.clicked.connect (on_rotate_counterclockwise);
 
         return base.on_ctrl_pressed (event);
     }
@@ -852,12 +857,8 @@ public abstract class CollectionPage : MediaPage {
     protected override bool on_ctrl_released (Gdk.EventKey? event) {
         flip_button.image = new Gtk.Image.from_icon_name (Resources.HFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
-        rotate_button.image = new Gtk.Image.from_icon_name (Resources.CLOCKWISE, Gtk.IconSize.LARGE_TOOLBAR);
-        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
         flip_button.clicked.disconnect (on_flip_vertically);
         flip_button.clicked.connect (on_flip_horizontally);
-        rotate_button.clicked.disconnect (on_rotate_counterclockwise);
-        rotate_button.clicked.connect (on_rotate_clockwise);
 
         return base.on_ctrl_released (event);
     }

--- a/src/Views/DirectPhotoPage.vala
+++ b/src/Views/DirectPhotoPage.vala
@@ -320,7 +320,8 @@ public class DirectPhotoPage : EditingHostPage {
         }
 
         base.update_actions (selected_count, count);
-        rotate_button.sensitive = rotate_possible;
+        rotate_left_button.sensitive = rotate_possible;
+        rotate_right_button.sensitive = rotate_possible;
     }
 
     private bool check_ok_to_close_photo (Photo photo) {

--- a/src/Views/EditingHostPage.vala
+++ b/src/Views/EditingHostPage.vala
@@ -69,7 +69,8 @@ public abstract class EditingHostPage : SinglePhotoPage {
     private ViewCollection? parent_view = null;
     private Gdk.Pixbuf swapped = null;
     private bool pixbuf_dirty = true;
-    protected Gtk.Button? rotate_button = null;
+    protected Gtk.Button? rotate_left_button = null;
+    protected Gtk.Button? rotate_right_button = null;
     private Gtk.Button? flip_button = null;
     private Gtk.ToggleButton? crop_button = null;
     private Gtk.ToggleButton? redeye_button = null;
@@ -122,9 +123,13 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected override void add_toolbar_widgets (Gtk.ActionBar toolbar) {
-        rotate_button = new Gtk.Button.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR);
-        rotate_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
-        rotate_button.clicked.connect (on_rotate_clockwise);
+        rotate_left_button = new Gtk.Button.from_icon_name ("object-rotate-left", Gtk.IconSize.LARGE_TOOLBAR);
+        rotate_left_button.tooltip_text = Resources.ROTATE_CCW_TOOLTIP;
+        rotate_left_button.clicked.connect (on_rotate_counterclockwise);
+
+        rotate_right_button = new Gtk.Button.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR);
+        rotate_right_button.tooltip_text = Resources.ROTATE_CW_TOOLTIP;
+        rotate_right_button.clicked.connect (on_rotate_clockwise);
 
         flip_button = new Gtk.Button.from_icon_name ("object-flip-horizontal", Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.tooltip_text = Resources.HFLIP_TOOLTIP;
@@ -195,7 +200,8 @@ public abstract class EditingHostPage : SinglePhotoPage {
         toolbar.pack_start (prev_button);
         toolbar.pack_start (next_button);
         toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        toolbar.pack_start (rotate_button);
+        toolbar.pack_start (rotate_left_button);
+        toolbar.pack_start (rotate_right_button);
         toolbar.pack_start (flip_button);
         toolbar.pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         toolbar.pack_start (crop_button);
@@ -580,7 +586,8 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected void enable_rotate (bool should_enable) {
-        rotate_button.set_sensitive (should_enable);
+        rotate_left_button.set_sensitive (should_enable);
+        rotate_right_button.set_sensitive (should_enable);
     }
 
     // This function should be called if the viewport has changed and the pixbuf cache needs to be
@@ -762,7 +769,8 @@ public abstract class EditingHostPage : SinglePhotoPage {
         bool sensitivity = !missing;
 
         flip_button.sensitive = sensitivity;
-        rotate_button.sensitive = sensitivity;
+        rotate_left_button.sensitive = sensitivity;
+        rotate_right_button.sensitive = sensitivity;
         crop_button.sensitive = sensitivity;
         straighten_button.sensitive = sensitivity;
         redeye_button.sensitive = sensitivity;
@@ -1021,7 +1029,9 @@ public abstract class EditingHostPage : SinglePhotoPage {
         Photo? photo = get_photo ();
         Scaling scaling = get_canvas_scaling ();
 
-        rotate_button.sensitive = ((photo != null) && (!photo_missing) && photo.check_can_rotate ()) ?
+        rotate_left_button.sensitive = ((photo != null) && (!photo_missing) && photo.check_can_rotate ()) ?
+                                  is_rotate_available (photo) : false;
+        rotate_right_button.sensitive = ((photo != null) && (!photo_missing) && photo.check_can_rotate ()) ?
                                   is_rotate_available (photo) : false;
         crop_button.sensitive = ((photo != null) && (!photo_missing)) ?
                                 EditingTools.CropTool.is_available (photo, scaling) : false;
@@ -1767,12 +1777,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected override bool on_ctrl_pressed (Gdk.EventKey? event) {
-        rotate_button.image = (new Gtk.Image.from_icon_name ("object-rotate-left", Gtk.IconSize.LARGE_TOOLBAR));
-        rotate_button.set_tooltip_text (Resources.ROTATE_CCW_TOOLTIP);
-        rotate_button.show_all ();
-        rotate_button.clicked.disconnect (on_rotate_clockwise);
-        rotate_button.clicked.connect (on_rotate_counterclockwise);
-
         flip_button.image = new Gtk.Image.from_icon_name (Resources.VFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.set_tooltip_text (Resources.VFLIP_TOOLTIP);
         flip_button.clicked.disconnect (on_flip_horizontally);
@@ -1785,12 +1789,6 @@ public abstract class EditingHostPage : SinglePhotoPage {
     }
 
     protected override bool on_ctrl_released (Gdk.EventKey? event) {
-        rotate_button.image = new Gtk.Image.from_icon_name ("object-rotate-right", Gtk.IconSize.LARGE_TOOLBAR);
-        rotate_button.set_tooltip_text (Resources.ROTATE_CW_TOOLTIP);
-        rotate_button.show_all ();
-        rotate_button.clicked.disconnect (on_rotate_counterclockwise);
-        rotate_button.clicked.connect (on_rotate_clockwise);
-
         flip_button.image = new Gtk.Image.from_icon_name (Resources.HFLIP, Gtk.IconSize.LARGE_TOOLBAR);
         flip_button.set_tooltip_text (Resources.HFLIP_TOOLTIP);
         flip_button.clicked.disconnect (on_flip_vertically);


### PR DESCRIPTION
Fixes #745

This solves feature request #745 by splitting the two rotate actions into separate buttons:

<img width="1166" height="638" alt="afbeelding" src="https://github.com/user-attachments/assets/dd7aa86d-f209-4abe-9870-4384376b5fcb" />


(If this is desirable, I will create a second PR for doing the same to the Flip button).